### PR TITLE
Add method to reload dataset schema

### DIFF
--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -30,6 +30,9 @@ class Stream:
 		self.autoload = autoload
 		self.streamtype = StreamType.NONE
 
+	def load(self):
+		raise NotImplementedError("load() method is not implemented for the Stream base class.")
+
 	def plot(self, col = None , **kwargs):
 		if self.data.empty:
 			raise ValueError("Input dataframe is empty.")

--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -17,10 +17,14 @@ class UbxStream(Stream):
 		self.positiondata = None
 		self.clock_calib_model = None  # Store the model here
 		self.streamtype = StreamType.UBX
+		self.autoload_messages = autoload_messages
 		if self.autoload:
-			self.load_event_list(autoload_messages)
+			self.load_event_list(self.autoload_messages)
 
-	def load(self, event: _UBX_MSGIDS):
+	def load(self):
+		self.load_event_list(self.autoload_messages)
+
+	def load_event(self, event: _UBX_MSGIDS):
 		self._update_dotmap(event,
                       load_ubx_event_stream(
                           event,
@@ -35,7 +39,7 @@ class UbxStream(Stream):
 
 	def load_event_list(self, events: list):
 		for event in events:
-			self.load(event)
+			self.load_event(event)
 
 	def parseposition(self,
                    event: _UBX_MSGIDS = _UBX_MSGIDS.NAV_HPPOSLLH,


### PR DESCRIPTION
Closes #4 
Adds the method to `Dataset` class to reload ( `dataset.reload_streams()` ) all the streams in the schema.
Eg.:
```python
stream_root_folder = r"path"
dataset = Dataset(stream_root_folder, datasetlabel='label', georeference= Georeference())

dataset.populate_streams(autoload = False)
dataset.streams.UBX.autoload=True
dataset.reload_streams(force_load=False)
dataset.export_streams()
```