### PR TITLE
11 clock reference

### DIFF
--- a/pluma/schema/dataset.py
+++ b/pluma/schema/dataset.py
@@ -55,21 +55,23 @@ class Dataset:
         """
         if ubxstream is None:
             try:
-                navdata = self.streams.UBX.parseposition(
-                    event=event,
-                    calibrate_clock=calibrate_clock)
+                ubxstream = self.streams.UBX
             except:
                 raise ImportError('Could not load Ubx stream.')
+
+        if not(ubxstream.streamtype == StreamType.UBX):
+            raise TypeError("Reference must be a UBX Stream")
         else:
-            if not(ubxstream.streamtype == StreamType.UBX):
-                raise TypeError("Reference must be a Ubx Stream")
-            else:
-                navdata = ubxstream.parseposition(
-                    event=event,
-                    calibrate_clock=calibrate_clock)
+            navdata = ubxstream.parseposition(
+                event=event,
+                calibrate_clock=calibrate_clock)
+
         self.georeference.from_dataframe(navdata)
         if strip is True:
             self.georeference.strip()
+        if calibrate_clock is True:
+            self.georeference.clockreferencing.reference =\
+                ubxstream.clockreferencering.reference
 
     def reload_streams(self,
                        schema: Union[DotMap, Stream, None] = None,
@@ -167,13 +169,13 @@ class Dataset:
             If < r2_min_qc, an error will be raised, since it likely\
                 results from an automatic correction procedure. Defaults to 0.99.
         """
-        self.streams.UBX.clock_calib_model =\
-            get_clockcalibration_ubx_to_harp_clock(
+        model = get_clockcalibration_ubx_to_harp_clock(
                 ubx_stream=self.streams.UBX,
                 harp_sync=self.streams.BioData.Set.data,
                 dt_error=dt_error,
                 r2_min_qc=r2_min_qc,
                 plot_diagnosis=plot_diagnosis)
+        return model
 
     def showmap(self, **kwargs):
         """Overload to plotting.showmap that shows spatial information color-coded by time.

--- a/pluma/schema/dataset.py
+++ b/pluma/schema/dataset.py
@@ -5,6 +5,8 @@ from typing import Union
 
 from pluma.schema.outdoor import build_schema
 from pluma.sync.ubx2harp import get_clockcalibration_ubx_to_harp_clock
+from pluma.sync import ClockRefId
+
 from pluma.stream import StreamType, Stream
 
 from pluma.plotting import maps
@@ -169,13 +171,17 @@ class Dataset:
             If < r2_min_qc, an error will be raised, since it likely\
                 results from an automatic correction procedure. Defaults to 0.99.
         """
+
         model = get_clockcalibration_ubx_to_harp_clock(
                 ubx_stream=self.streams.UBX,
                 harp_sync=self.streams.BioData.Set.data,
                 dt_error=dt_error,
                 r2_min_qc=r2_min_qc,
                 plot_diagnosis=plot_diagnosis)
-        return model
+
+        self.streams.UBX.clockreferencering.set_conversion_model(
+            model=model,
+            reference_from=ClockRefId.HARP)
 
     def showmap(self, **kwargs):
         """Overload to plotting.showmap that shows spatial information color-coded by time.

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 from typing import Union
 
 from pluma.io.path_helper import ComplexPath
-
+from pluma.sync import ClockReferencering, ClockRefId
 class StreamType(Enum):
 	NONE = None
 	UBX = 'UbxStream'
@@ -22,20 +22,24 @@ class Stream:
               streamlabel: str,
               root: Union[str, ComplexPath] = '',
               data: any = None,
+              clockreferencering:
+                  ClockReferencering = ClockReferencering(
+                      referenceid=ClockRefId.NONE),
               autoload: bool = True):
 		"""_summary_
 		Args:
 			device (str): Device label
 			streamlabel (str): Stream label
-			root (str, optional): Root path where the files of the stream are expected to be found. Defaults to ''.
+			root (Union[str, ComplexPath], optional): Root path where the files of the stream are expected to be found. Defaults to ''.
 			data (any, optional): Data to initially populate the stream. Defaults to None.
-			autoload (bool, optional): If True, it will attempt to automatically load the data when instantiated. Defaults to True.
+   			autoload (bool, optional): If True, it will attempt to automatically load the data when instantiated. Defaults to True.
 		"""
 
 		self.device = device
 		self.streamlabel = streamlabel
 		self._rootfolder = self.rootfolder = root
 		self.data = data
+		self.clockreferencering = clockreferencering
 		self.autoload = autoload
 		self.streamtype = StreamType.NONE
 
@@ -46,7 +50,6 @@ class Stream:
 	@rootfolder.setter
 	def rootfolder(self, value: Union[str, ComplexPath]):
 		self._rootfolder = value
-
 
 	def load(self):
 		raise NotImplementedError("load() method is not implemented for the Stream base class.")

--- a/pluma/stream/accelerometer.py
+++ b/pluma/stream/accelerometer.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.io.accelerometer import load_accelerometer, _accelerometer_header
+from pluma.sync import ClockRefId
 
 
 class AccelerometerStream(Stream):
@@ -15,10 +16,15 @@ class AccelerometerStream(Stream):
               data: pd.DataFrame = pd.DataFrame(
                   columns=_accelerometer_header),
               si_conversion: SiUnitConversion = SiUnitConversion(),
+              clockreferenceid: ClockRefId = ClockRefId.HARP,
               **kw):
-		super(AccelerometerStream, self).__init__(data=data, **kw)
+
+		super(AccelerometerStream, self).__init__(
+                                            data=data,
+                                            **kw)
 		self.streamtype = StreamType.ACCELEROMETER
 		self.si_conversion = si_conversion
+		self.clockreferencering.reference = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -1,5 +1,6 @@
 from pluma.stream import Stream, StreamType
 from pluma.io.empatica import load_empatica
+from pluma.sync import ClockRefId
 
 
 class EmpaticaStream(Stream):
@@ -8,9 +9,13 @@ class EmpaticaStream(Stream):
 	Args:
 		Stream (_type_): _description_
 	"""
-	def __init__(self, **kw):
+	def __init__(self,
+              clockreferenceid: ClockRefId = ClockRefId.HARP,
+              **kw):
 		super(EmpaticaStream, self).__init__(**kw)
 		self.streamtype = StreamType.EMPATICA
+		self.clockreferencering.reference = clockreferenceid
+
 		if self.autoload:
 			self.load()
 

--- a/pluma/stream/georeference.py
+++ b/pluma/stream/georeference.py
@@ -1,12 +1,13 @@
 import pandas as pd
 import geopandas
 
-import shapely
 import warnings
 from shapely.errors import ShapelyDeprecationWarning
 warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
 import pluma.plotting.export as plumaexport
+
+
 class Georeference():
 
     _georeference_header = ["Seconds", "Longitude", "Latitude", "Elevation"]
@@ -18,12 +19,13 @@ class Georeference():
                  lat: pd.Series = pd.Series(dtype=float),
                  height: pd.Series = pd.Series(dtype=float)) -> None:
         self._spacetime = self._build_spacetime_from_dataframe(spacetime)
-        if self._spacetime is None:  # if no spacetime is provided attempt to assemble it individually
+        if self._spacetime is None:
+            # if no spacetime is provided attempt to assemble it individually
             self._time = time
             self._lon = lon
             self._lat = lat
             self._height = height
-            self._spacetime = self._build_spacetime_from_series()
+            self._build_spacetime_from_series()
         else:
             self._refresh_properties()
 
@@ -167,8 +169,9 @@ class Georeference():
     def strip(self):
         tokeep = Georeference._georeference_header[1:]
         tokeep.append('geometry')
-        self.spacetime = self.spacetime.loc[:, self.spacetime.columns.intersection(
-            tokeep)]
+        self.spacetime = self.spacetime.loc[
+            :,
+            self.spacetime.columns.intersection(tokeep)]
 
     def __str__(self) -> str:
         return str(self.spacetime)
@@ -177,7 +180,7 @@ class Georeference():
         return repr(self.spacetime)
 
     def export_kml(self,
-                   export_path:str = "walk.kml",
+                   export_path: str = "walk.kml",
                    **kwargs):
         plumaexport.export_kml_line(
             df=self.spacetime,

--- a/pluma/stream/georeference.py
+++ b/pluma/stream/georeference.py
@@ -6,7 +6,7 @@ from shapely.errors import ShapelyDeprecationWarning
 warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
 import pluma.plotting.export as plumaexport
-
+from pluma.sync import ClockReferencering, ClockRefId
 
 class Georeference():
 
@@ -17,7 +17,8 @@ class Georeference():
                  time: pd.Series = pd.Series(dtype='datetime64[ns]'),
                  lon: pd.Series = pd.Series(dtype=float),
                  lat: pd.Series = pd.Series(dtype=float),
-                 height: pd.Series = pd.Series(dtype=float)) -> None:
+                 height: pd.Series = pd.Series(dtype=float),
+                 clockreferenceid: ClockRefId = ClockRefId.NONE) -> None:
         self._spacetime = self._build_spacetime_from_dataframe(spacetime)
         if self._spacetime is None:
             # if no spacetime is provided attempt to assemble it individually
@@ -28,6 +29,7 @@ class Georeference():
             self._build_spacetime_from_series()
         else:
             self._refresh_properties()
+        self.clockreferencing = ClockReferencering(referenceid=clockreferenceid)
 
     @property
     def spacetime(self):

--- a/pluma/stream/georeference.py
+++ b/pluma/stream/georeference.py
@@ -8,6 +8,7 @@ warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 import pluma.plotting.export as plumaexport
 from pluma.sync import ClockReferencering, ClockRefId
 
+
 class Georeference():
 
     _georeference_header = ["Seconds", "Longitude", "Latitude", "Elevation"]

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -6,6 +6,8 @@ from pluma.io.harp import load_harp_stream, _HARP_T0
 
 from pluma.stream.siconversion import SiUnitConversion
 
+from pluma.sync import ClockRefId
+
 
 class HarpStream(Stream):
 	"""_summary_
@@ -18,12 +20,13 @@ class HarpStream(Stream):
               data: pd.DataFrame = pd.DataFrame(
                   columns=['Seconds', 'Value']),
               si_conversion: SiUnitConversion = SiUnitConversion(),
+              clockreferenceid: ClockRefId = ClockRefId.HARP,
               **kw):
 		super(HarpStream, self).__init__(data=data, **kw)
 		self.eventcode = eventcode
 		self.streamtype = StreamType.HARP
-
 		self.si_conversion = si_conversion
+		self.clockreferencering.reference = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/microphone.py
+++ b/pluma/stream/microphone.py
@@ -3,6 +3,8 @@ import numpy as np
 from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.io.microphone import load_microphone
+from pluma.sync import ClockRefId
+
 
 class MicrophoneStream (Stream):
 	"""_summary_
@@ -15,12 +17,14 @@ class MicrophoneStream (Stream):
               fs: float = None,
               channels: int = 2,
               si_conversion: SiUnitConversion = SiUnitConversion(),
+              clockreferenceid: ClockRefId = ClockRefId.HARP,
               **kw):
 		super(MicrophoneStream, self).__init__(data=data, **kw)
 		self.streamtype = StreamType.MICROPHONE
 		self.fs = fs
 		self.channels = channels
 		self.si_conversion = si_conversion
+		self.clockreferencering.reference = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -71,9 +71,7 @@ class UbxStream(Stream):
 		return NavData
 
 	def calibrate_itow(self, input_itow_array):
-		model = self.clock_calib_model
-		calibrated_itow = model.predict(input_itow_array)
-		return calibrated_itow
+		return self.clockreferencering.conversion_model(input_itow_array)
 
 	def __str__(self):
 		return f'Ubx stream from device {self.device}, stream {self.streamlabel}'

--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -5,6 +5,7 @@ from dotmap import DotMap
 from pluma.stream import Stream, StreamType
 from pluma.stream.harp import HarpStream
 from pluma.io.ubx import load_ubx_event_stream, _UBX_MSGIDS, _UBX_CLASSES
+from pluma.sync import ClockRefId
 
 
 class UbxStream(Stream):
@@ -12,11 +13,14 @@ class UbxStream(Stream):
 	def __init__(self,
               data: DotMap = DotMap(),
               autoload_messages: list = [],
+              clockreferenceid: ClockRefId = ClockRefId.GNSS,
               **kw):
 		super(UbxStream, self).__init__(data=data, **kw)
 		self.positiondata = None
-		self.clock_calib_model = None  # Store the model here
 		self.streamtype = StreamType.UBX
+		self.clockreferencering.reference = clockreferenceid
+		self.clock_calib_model = None  # Store the model here
+
 		self.autoload_messages = autoload_messages
 		if self.autoload:
 			self.load_event_list(self.autoload_messages)

--- a/pluma/sync/__init__.py
+++ b/pluma/sync/__init__.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from enum import Enum
-from typing import Callable
+from typing import Callable, Union
+from sklearn.linear_model import LinearRegression
+
 
 
 class ClockRefId(Enum):
@@ -36,17 +38,19 @@ class ClockReferencering:
 		return self._conversion_model
 
 	@conversion_model.setter
-	def conversion_model(self, value: Callable):
-		self._conversion_model = value
+	def conversion_model(self, value: Union[Callable, LinearRegression]):
+		if isinstance(value, LinearRegression):
+			self._conversion_model = value.predict
+		else:
+			self._conversion_model = value
 
-	def rereference_time(self, df: pd.DataFrame):
+	def rereference_time(self, timearray):
 		"""Takes the index column in the dataframe and applies a correction model.
 
 		Returns:
 			_type_: _description_
 		"""
-		raise NotImplementedError("TODO")
 		conversion_fun = self.conversion_model
 		if conversion_fun is None:
 			raise ValueError("No valid model was instantiated.")
-		return None
+		return conversion_fun(timearray)

--- a/pluma/sync/__init__.py
+++ b/pluma/sync/__init__.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from enum import Enum
+from typing import Callable
+
+
+class ClockRefId(Enum):
+	NONE = None
+	GNSS = 'gnss'
+	HARP = 'harp'
+	CPU = 'cpu'
+
+
+class ClockReferencering:
+	"""Abstract class that allows synchronization across Streams
+	"""
+
+	def __init__(self,
+              referenceid: ClockRefId = ClockRefId.NONE):
+
+		self._clockreference = referenceid  # Tracks the reference clock
+		self._clockreference_history = []
+		self._conversion_model = None
+
+	@property
+	def reference(self):
+		return self._clockreference
+
+	@reference.setter
+	def reference(self, value: ClockRefId):
+		if not(value == self._clockreference):
+			self._clockreference = value
+			self._clockreference_history.append(value)
+
+	@property
+	def conversion_model(self):
+		return self._conversion_model
+
+	@conversion_model.setter
+	def conversion_model(self, value: Callable):
+		self._conversion_model = value
+
+	def rereference_time(self, df: pd.DataFrame):
+		"""Takes the index column in the dataframe and applies a correction model.
+
+		Returns:
+			_type_: _description_
+		"""
+		raise NotImplementedError("TODO")
+		conversion_fun = self.conversion_model
+		if conversion_fun is None:
+			raise ValueError("No valid model was instantiated.")
+		return None

--- a/pluma/sync/__init__.py
+++ b/pluma/sync/__init__.py
@@ -22,6 +22,8 @@ class ClockReferencering:
 		self._clockreference = referenceid  # Tracks the reference clock
 		self._clockreference_history = []
 		self._conversion_model = None
+		self._reference_to = ClockRefId.NONE
+		self._reference_from = ClockRefId.NONE
 
 	@property
 	def reference(self):
@@ -31,6 +33,7 @@ class ClockReferencering:
 	def reference(self, value: ClockRefId):
 		if not(value == self._clockreference):
 			self._clockreference = value
+			self._reference_to = value
 			self._clockreference_history.append(value)
 
 	@property
@@ -38,11 +41,32 @@ class ClockReferencering:
 		return self._conversion_model
 
 	@conversion_model.setter
-	def conversion_model(self, value: Union[Callable, LinearRegression]):
+	def conversion_model(self,
+                      value: Union[Callable, LinearRegression]):
 		if isinstance(value, LinearRegression):
 			self._conversion_model = value.predict
 		else:
 			self._conversion_model = value
+
+	@property
+	def reference_to(self):
+		return self._reference_to
+
+	@reference_to.setter
+	def reference_to(self, value: ClockRefId):
+		self._reference_to = value
+
+	@property
+	def reference_from(self):
+		return self._reference_from
+
+	@reference_from.setter
+	def reference_from(self, value: ClockRefId):
+		self._reference_from = value
+
+	def set_conversion_model(self, model, reference_from):
+		self.conversion_model = model
+		self.reference_from = reference_from
 
 	def rereference_time(self, timearray):
 		"""Takes the index column in the dataframe and applies a correction model.

--- a/pluma/sync/ubx2harp.py
+++ b/pluma/sync/ubx2harp.py
@@ -143,7 +143,6 @@ def align_ubx_to_harp(
         plt.ylabel('$\Delta t$ (s)')
         plt.xlabel('Trial number')
         plt.legend()
-
         plt.show()
 
     return pulses_lookup


### PR DESCRIPTION
This PR generalizes the synchronization across devices by implementing a ClockReferencing class.

The class instantiates a `conversion_model` and keeps track of the expected input and output of the transformation.
The synchronization of the UBX to Harp has been refactored to reflect this change.
In the future, this class will also be used to modify all streams of a given reference (e.g. Harp) to another temporal reference (e.g. GNSS-UTC)

closes #11 