### PR TITLE
Add support for rereferencing exported dataset time attribute

### DIFF
--- a/pluma/export/sdi.py
+++ b/pluma/export/sdi.py
@@ -13,7 +13,7 @@ exclude_devices = ["PupilLabs", "Microphone", "Empatica", "BioData", "UBX"]
 
 def convert_dataset_to_sdi(
         dataset,
-        sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+        sampling_dt: datetime.timedelta = datetime.timedelta(seconds=1),
         rereference_to_ubx_time: bool = False
         ):
 
@@ -50,7 +50,7 @@ def convert_dataset_to_sdi(
 
 def export_dataset_to_sdi_record(
         dataset,
-        sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+        sampling_dt: datetime.timedelta = datetime.timedelta(seconds=1),
         rereference_to_ubx_time: bool = False,
         filename=None
         ):

--- a/pluma/export/sdi.py
+++ b/pluma/export/sdi.py
@@ -26,19 +26,21 @@ def convert_dataset_to_sdi(
     out = streams_to_export[list(streams_to_export.keys())[0]].copy()
     out = out.iloc[:, 0:3]
 
+    out_columns = []
     for stream in streams_to_export:
         cols = list(streams_to_export[stream].columns)
         for idx, entry in enumerate(cols):
             if entry not in exclude:
                 cols[idx] = f"{stream}.{entry}"
         streams_to_export[stream].columns = cols
-        out = pd.merge(out, streams_to_export[stream], how='outer')
+        out_columns.append(streams_to_export[stream].drop(exclude, axis=1))
+    out = out.join(out_columns)
 
     geometry = gpd.points_from_xy(
         x=out['Longitude'],
         y=out['Latitude'],
         z=out['Elevation'])
-    out = gpd.GeoDataFrame(out.drop(exclude, axis=1), geometry=geometry)
+    out = gpd.GeoDataFrame(out.drop(exclude, axis=1).reset_index(names='time'), geometry=geometry)
     return out
 
 def export_dataset_to_sdi_record(

--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -88,9 +88,9 @@ def resample_stream_accelerometer(stream: Stream,
         'Accl.X': resampling.resample_temporospatial,
         'Accl.Y': resampling.resample_temporospatial,
         'Accl.Z': resampling.resample_temporospatial,
-        'Gravitiy.X': resampling.resample_temporospatial,
-        'Gravitiy.Y': resampling.resample_temporospatial,
-        'Gravitiy.Z': resampling.resample_temporospatial}
+        'Gravity.X': resampling.resample_temporospatial,
+        'Gravity.Y': resampling.resample_temporospatial,
+        'Gravity.Z': resampling.resample_temporospatial}
     georef = _get_georef(stream)
     resampled_data = {k: resampling_method(stream.data[k], georef, sampling_dt)
                       for k, resampling_method in col_sampler.items()

--- a/pluma/io/accelerometer.py
+++ b/pluma/io/accelerometer.py
@@ -13,7 +13,7 @@ _accelerometer_header = [
     'LinearAccl.X', 'LinearAccl.Y', 'LinearAccl.Z',
     'Magnetometer.X', 'Magnetometer.Y', 'Magnetometer.Z',
     'Accl.X', 'Accl.Y', 'Accl.Z',
-    'Gravitiy.X', 'Gravitiy.Y', 'Gravitiy.Z',
+    'Gravity.X', 'Gravity.Y', 'Gravity.Z',
     'SysCalibEnabled', 'GyroCalibEnabled',
     'AccCalibEnabled', 'MagCalibEnabled',
     'Temperature', 'Seconds', 'SoftwareTimestamp']

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -235,12 +235,12 @@ class Dataset:
             raise AssertionError('Dataset is already been automatically calibrated.')
         
     def convert_to_sdi(self,
-                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=1),
                       rereference_to_ubx_time: bool = False):
         return convert_dataset_to_sdi(self, sampling_dt, rereference_to_ubx_time)
 
     def export_to_sdi_record(self,
-                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=1),
                       rereference_to_ubx_time: bool = False,
                       filename=None):
         export_dataset_to_sdi_record(self, sampling_dt, rereference_to_ubx_time, filename=filename)

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -235,10 +235,12 @@ class Dataset:
             raise AssertionError('Dataset is already been automatically calibrated.')
         
     def convert_to_sdi(self,
-                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2)):
-        return convert_dataset_to_sdi(self, sampling_dt=sampling_dt)
+                      sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+                      rereference_to_ubx_time: bool = False):
+        return convert_dataset_to_sdi(self, sampling_dt, rereference_to_ubx_time)
 
     def export_to_sdi_record(self,
                       sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2),
+                      rereference_to_ubx_time: bool = False,
                       filename=None):
-        export_dataset_to_sdi_record(self, sampling_dt=sampling_dt, filename=filename)
+        export_dataset_to_sdi_record(self, sampling_dt, rereference_to_ubx_time, filename=filename)

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -80,8 +80,8 @@ class Dataset:
         if strip is True:
             self.georeference.strip()
         if calibrate_clock is True:
-            self.georeference.clockreferencing.reference =\
-                ubxstream.clockreferencering.reference
+            self.georeference.clockreference.referenceid =\
+                ubxstream.clockreference.referenceid
 
     def reload_streams(self,
                        schema: Union[DotMap, Stream, None] = None,
@@ -213,7 +213,7 @@ class Dataset:
                 r2_min_qc=r2_min_qc,
                 plot_diagnosis=plot_diagnosis)
 
-        self.streams.UBX.clockreferencering.set_conversion_model(
+        self.streams.UBX.clockreference.set_conversion_model(
             model=model,
             reference_from=ClockRefId.HARP)
         self.has_calibration = True

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 from typing import Union, Optional
 
 from pluma.io.path_helper import ComplexPath
-from pluma.sync import ClockReferencering, ClockRefId
+from pluma.sync import ClockReference, ClockRefId
 
 
 class StreamType(Enum):
@@ -24,7 +24,7 @@ class Stream:
               streamlabel: str,
               root: Union[str, ComplexPath] = '',
               data: any = None,
-              clockreferencering: ClockReferencering=ClockReferencering(referenceid=ClockRefId.NONE),
+              clockreference: ClockReference=ClockReference(referenceid=ClockRefId.NONE),
 			  parent_dataset=None,
 			  autoload: bool = True):
 		"""_summary_
@@ -40,7 +40,7 @@ class Stream:
 		self.streamlabel = streamlabel
 		self._rootfolder = self.rootfolder = root
 		self.data = data
-		self.clockreferencering = clockreferencering
+		self.clockreference = clockreference
 		self.parent_dataset = parent_dataset
 		self.autoload = autoload
 		self.streamtype = StreamType.NONE

--- a/pluma/stream/accelerometer.py
+++ b/pluma/stream/accelerometer.py
@@ -25,7 +25,7 @@ class AccelerometerStream(Stream):
                                             **kw)
 		self.streamtype = StreamType.ACCELEROMETER
 		self.si_conversion = si_conversion
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -26,12 +26,12 @@ class EegStream(Stream):
 
 		super(EegStream, self).__init__(data=data, **kw)
 		self.streamtype = StreamType.EEG
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 		self.autoalign = autoalign
 		self.server_lsl_marker = server_lsl_marker
 		if self.autoload:
 			self.load()
-			if (self.autoalign and (self.clockreferencering.reference == ClockRefId.HARP)):
+			if (self.autoalign and (self.clockreference.referenceid == ClockRefId.HARP)):
 				self.align_to_harp()
 
 	def load(self):
@@ -40,7 +40,7 @@ class EegStream(Stream):
 			root=self.rootfolder)
 		if self.server_lsl_marker is None:
 			self.server_lsl_marker = _lsl_timestamp
-			if (self.autoalign and (self.clockreferencering.reference == ClockRefId.HARP)):
+			if (self.autoalign and (self.clockreference.referenceid == ClockRefId.HARP)):
 				self.align_to_harp()
 
 	def align_to_harp(self):

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -18,7 +18,7 @@ class EmpaticaStream(Stream):
               **kw):
 		super(EmpaticaStream, self).__init__(**kw)
 		self.streamtype = StreamType.EMPATICA
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/georeference.py
+++ b/pluma/stream/georeference.py
@@ -6,7 +6,7 @@ from shapely.errors import ShapelyDeprecationWarning
 warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
 from pluma.export.maps import export_kml_line
-from pluma.sync import ClockReferencering, ClockRefId
+from pluma.sync import ClockReference, ClockRefId
 
 
 class Georeference():
@@ -30,7 +30,7 @@ class Georeference():
             self._build_spacetime_from_series()
         else:
             self._refresh_properties()
-        self.clockreferencing = ClockReferencering(referenceid=clockreferenceid)
+        self.clockreference = ClockReference(referenceid=clockreferenceid)
 
     @property
     def spacetime(self):

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -29,7 +29,7 @@ class HarpStream(Stream):
 		self.eventcode = eventcode
 		self.streamtype = StreamType.HARP
 		self.si_conversion = si_conversion
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/microphone.py
+++ b/pluma/stream/microphone.py
@@ -24,7 +24,7 @@ class MicrophoneStream (Stream):
 		self.fs = fs
 		self.channels = channels
 		self.si_conversion = si_conversion
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 
 		if self.autoload:
 			self.load()

--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -18,7 +18,7 @@ class UbxStream(Stream):
 		super(UbxStream, self).__init__(data=data, **kw)
 		self.positiondata = None
 		self.streamtype = StreamType.UBX
-		self.clockreferencering.reference = clockreferenceid
+		self.clockreference.referenceid = clockreferenceid
 		self.clock_calib_model = None  # Store the model here
 
 		self.autoload_messages = autoload_messages
@@ -71,7 +71,7 @@ class UbxStream(Stream):
 		return NavData
 
 	def calibrate_itow(self, input_itow_array):
-		return self.clockreferencering.conversion_model(input_itow_array)
+		return self.clockreference.conversion_model(input_itow_array)
 
 	def __str__(self):
 		return f'Ubx stream from device {self.device}, stream {self.streamlabel}'

--- a/pluma/sync/__init__.py
+++ b/pluma/sync/__init__.py
@@ -12,29 +12,29 @@ class ClockRefId(Enum):
 	EEG = 'eeg'
 
 
-class ClockReferencering:
+class ClockReference:
 	"""Abstract class that allows synchronization across Streams
 	"""
 
 	def __init__(self,
               referenceid: ClockRefId = ClockRefId.NONE):
 
-		self._clockreference = referenceid  # Tracks the reference clock
-		self._clockreference_history = []
+		self._referenceid = referenceid  # Tracks the reference clock
+		self._referenceid_history = []
 		self._conversion_model = None
 		self._reference_to = ClockRefId.NONE
 		self._reference_from = ClockRefId.NONE
 
 	@property
-	def reference(self):
-		return self._clockreference
+	def referenceid(self):
+		return self._referenceid
 
-	@reference.setter
-	def reference(self, value: ClockRefId):
-		if not(value == self._clockreference):
-			self._clockreference = value
+	@referenceid.setter
+	def referenceid(self, value: ClockRefId):
+		if not(value == self._referenceid):
+			self._referenceid = value
 			self._reference_to = value
-			self._clockreference_history.append(value)
+			self._referenceid_history.append(value)
 
 	@property
 	def conversion_model(self):


### PR DESCRIPTION
This PR refactors the export SDI and other dataset methods to allow rereferencing the exported dataset time attribute to UBX in cases where an explicit offset was not provided at acquisition time.

None of the time relations between hardware events is changed. The exported rereferenced time is simply a fixed offset applied from the default Harp clock to match the timestamp of the first UBX position data frame. This option should only be used when exporting datasets where the acquisition system hardware clock was not set to the current UTC time.

Usage example:
```python
sdi = dataset.convert_to_sdi(rereference_to_ubx_time=True)
```

Terminology on a few classes and streams was also updated for clarity.