### PR TITLE
Keep exported frame time as primary index

### DIFF
--- a/pluma/export/sdi.py
+++ b/pluma/export/sdi.py
@@ -45,7 +45,7 @@ def convert_dataset_to_sdi(
         x=out['Longitude'],
         y=out['Latitude'],
         z=out['Elevation'])
-    out = gpd.GeoDataFrame(out.drop(exclude, axis=1).reset_index(names='time'), geometry=geometry)
+    out = gpd.GeoDataFrame(out.drop(exclude, axis=1), geometry=geometry)
     return out
 
 def export_dataset_to_sdi_record(


### PR DESCRIPTION
Keep frame time as primary index to preserve sampling frequency information.