### PR TITLE
Allow exporting existing geoframe to geojson

### DIFF
--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -57,10 +57,20 @@ def export_dataset_to_geojson(
         ):
     
     out = convert_dataset_to_geoframe(dataset, sampling_dt, rereference_to_ubx_time)
-    out = out.reset_index(names='time')
-    micro_format = '.%f' if sampling_dt.microseconds != 0 else ''
+    export_geoframe_to_geojson(out, filename)
+
+def export_geoframe_to_geojson(
+        frame,
+        filename):
+    micro_format = '.%f'
+    try:
+        if frame.index.freq.delta.to_pytimedelta().microseconds == 0:
+            micro_format = ''
+    except:
+        pass
+    out = frame.reset_index(names='time')
     out.time = out.time.dt.strftime(f"%Y-%m-%dT%H:%M:%S{micro_format}Z")
-    out.index.name = 'id'    
+    out.index.name = 'id'
     out.to_file(filename, driver='GeoJSON', index=True)
 
 def recursive_resample_stream(acc_dict, stream, sampling_dt):


### PR DESCRIPTION
This PR allows exporting existing geoframe to GeoJSON to allow pre-processing a synchronized and resampled dataset before exporting to file.