### PR TITLE
Allow creating an OGC API metadata record directly from a dataset

### DIFF
--- a/pluma/export/ogcapi/records.py
+++ b/pluma/export/ogcapi/records.py
@@ -6,6 +6,7 @@ from geopandas import GeoDataFrame
 from datetime import datetime
 
 from pluma.schema import Dataset
+from dataclasses import dataclass, field, fields
 
 _env = jinja2.Environment(
     loader=jinja2.PackageLoader("pluma"),
@@ -15,8 +16,29 @@ _template = _env.get_template("metadata_template.j2")
 def _format_timestamp(time_utc: datetime) -> str:
     return f"{time_utc.isoformat()}Z"
 
-class MetadataRecord:
-    def __init__(self, dataset: Dataset, gdf: GeoDataFrame) -> None:
+@dataclass
+class Contact:
+    name: str
+    institution: str
+    email: str
+
+@dataclass
+class Theme:
+    scheme_url: str
+    concepts: list[str] = field(default_factory=lambda: [])
+
+@dataclass
+class RecordProperties:
+    title: str
+    description: str
+    license: str
+    tool: str
+    keywords: list[str] = field(default_factory=lambda: [])
+    contacts: list[Contact] = field(default_factory=lambda: [])
+    themes: list[Theme] = field(default_factory=lambda: [])
+
+class DatasetRecord:
+    def __init__(self, dataset: Dataset, gdf: GeoDataFrame, properties: RecordProperties) -> None:
         root_path = Path(dataset.rootfolder.path)
         self.id = f"{root_path.name}.geojson"
         self.start_date = gdf.index[0]
@@ -26,6 +48,7 @@ class MetadataRecord:
         self.resolution = isodate.duration_isoformat(pd.Timedelta(gdf.index.freq))
         self.bounds = gdf.total_bounds
         self.crs = gdf.crs
+        self.properties = properties
 
     def to_json(self) -> str:
         return _template.render(
@@ -43,5 +66,5 @@ class MetadataRecord:
                 [self.bounds[0], self.bounds[1]]
             ]],
             crs=self.crs.to_string(),
-            keywords=[],
-            themes=[])
+            **(dict((field.name, getattr(self.properties, field.name))
+                    for field in fields(self.properties))))

--- a/pluma/export/ogcapi/records.py
+++ b/pluma/export/ogcapi/records.py
@@ -1,3 +1,4 @@
+import jinja2
 import isodate
 import pandas as pd
 from pathlib import Path
@@ -5,6 +6,14 @@ from geopandas import GeoDataFrame
 from datetime import datetime
 
 from pluma.schema import Dataset
+
+_env = jinja2.Environment(
+    loader=jinja2.PackageLoader("pluma"),
+    autoescape=jinja2.select_autoescape)
+_template = _env.get_template("metadata_template.j2")
+
+def _format_timestamp(time_utc: datetime) -> str:
+    return f"{time_utc.isoformat()}Z"
 
 class MetadataRecord:
     def __init__(self, dataset: Dataset, gdf: GeoDataFrame) -> None:
@@ -19,4 +28,20 @@ class MetadataRecord:
         self.crs = gdf.crs
 
     def to_json(self) -> str:
-        return ""
+        return _template.render(
+            id=self.id,
+            start_date=_format_timestamp(self.start_date),
+            end_date=_format_timestamp(self.end_date),
+            created_timestamp=_format_timestamp(self.created_timestamp),
+            updated_timestamp=_format_timestamp(self.updated_timestamp),
+            resolution=self.resolution,
+            coordinates=[[
+                [self.bounds[0], self.bounds[1]],
+                [self.bounds[0], self.bounds[3]],
+                [self.bounds[2], self.bounds[3]],
+                [self.bounds[2], self.bounds[1]],
+                [self.bounds[0], self.bounds[1]]
+            ]],
+            crs=self.crs.to_string(),
+            keywords=[],
+            themes=[])

--- a/pluma/export/ogcapi/records.py
+++ b/pluma/export/ogcapi/records.py
@@ -1,0 +1,22 @@
+import isodate
+import pandas as pd
+from pathlib import Path
+from geopandas import GeoDataFrame
+from datetime import datetime
+
+from pluma.schema import Dataset
+
+class MetadataRecord:
+    def __init__(self, dataset: Dataset, gdf: GeoDataFrame) -> None:
+        root_path = Path(dataset.rootfolder.path)
+        self.id = f"{root_path.name}.geojson"
+        self.start_date = gdf.index[0]
+        self.end_date = gdf.index[-1]
+        self.created_timestamp = pd.Timestamp(datetime.utcnow())
+        self.updated_timestamp = self.created_timestamp
+        self.resolution = isodate.duration_isoformat(pd.Timedelta(gdf.index.freq))
+        self.bounds = gdf.total_bounds
+        self.crs = gdf.crs
+
+    def to_json(self) -> str:
+        return ""

--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -7,7 +7,6 @@ import pandas as pd
 from typing import Union, Optional, Callable, Dict
 
 from pluma.stream import Stream, StreamType
-from pluma.stream.harp import HarpStream
 
 import pluma.preprocessing.resampling as resampling
 
@@ -46,7 +45,7 @@ def export_stream_to_csv(stream: Stream, export_path: str,
                                   {type(stream)} is not yet supported.")
 
 
-def export_uniform_table_stream(stream: HarpStream,
+def export_uniform_table_stream(stream: Stream,
                                 georeference: pd.DataFrame,
                                 outdir: str,
                                 resampling_function: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],

--- a/pluma/templates/metadata_template.j2
+++ b/pluma/templates/metadata_template.j2
@@ -1,0 +1,120 @@
+{
+  "id": "{{ id }}",
+  "conformsTo": [
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/req/record-core"
+  ],
+  "type": "Feature",
+  "time": {
+    "interval": [ "{{ start_date }}", "{{ end_date }}"],
+    "resolution": "{{ resolution }}"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": {{ coordinates | tojson(indent=2) | indent(width=4) }}
+  },
+  "properties": {
+    "created": "{{ created_timestamp }}",
+    "updated": "{{ updated_timestamp }}",
+    "type": "dataset",
+    "title": "{{ title }}",
+    "description": "{{ description }}",
+    "keywords": {{ keywords | tojson(indent=2) | indent(width=4) }},
+    "language": "en",
+    "contacts": [
+      {
+        "name": "{{ contact_name }}",
+        "organization": "{{ contact_institution }}",
+        "email": [
+          {"value" : "{{ contact_email }}"}
+        ]
+      }
+    ],
+    "themes": [
+      {
+        {% for theme in themes %}
+        "concepts": [
+          {% for concept in theme.concepts %}
+          {
+            "id": "{{ concept.scheme_concept }}"
+          }
+          {% endfor %}
+        ],
+        "scheme": "{{ theme.scheme_url }}"
+        {% endfor %}
+      }
+    ],
+    "formats": [
+      "CSV",
+      "GeoJSON"
+    ],
+    "license": "{{ license }}",
+    "dataCollectionTool": "{{ dataCollectionTool }}"
+  },
+  "links": [
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://emotional.byteroad.net/collections/ec_catalog/{{ id }}"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/geo+json",
+      "title": "This document as GeoJSON",
+      "href": "https://emotional.byteroad.net/collections/ec_catalog/{{ id }}?f=json"
+    },
+    {
+      "rel": "item",
+      "type": "image/png",
+      "title": "OGC Web Map Service (WMS)",
+      "href": "https://emotional.byteroad.net/geoserver/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers={{ id }}&width={width}&height={height}&format=image/png",
+      "templated": true,
+      "variables": {
+        "crs": {
+          "description": "...",
+          "type": "string",
+          "enum": [
+            "EPSG:4326",
+            "EPSG:3857"
+          ]
+        },
+        "bbox": {
+          "description": "...",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "minItems": 4,
+          "maxItems": 4
+        },
+        "width": {
+          "description": "...",
+          "type": "number",
+          "format": "integer",
+          "minimum": 600,
+          "maximum": 5000
+        },
+        "height": {
+          "description": "...",
+          "type": "number",
+          "format": "integer",
+          "minimum": 600,
+          "maximum": 5000
+        }
+      }
+    },
+    {
+      "rel": "item",
+      "type": "application/geo+json",
+      "title": "OGC API Features",
+      "href": "https://emotional.byteroad.net/collections/{{ id }}"
+    },
+    {
+      "rel": "item",
+      "type": "application/geo+json",
+      "title": "OGC API Tiles",
+      "href": "https://emotional.byteroad.net/collections/{{ id }}/tiles"
+    }
+  ]
+}

--- a/pluma/templates/metadata_template.j2
+++ b/pluma/templates/metadata_template.j2
@@ -21,34 +21,36 @@
     "keywords": {{ keywords | tojson(indent=2) | indent(width=4) }},
     "language": "en",
     "contacts": [
+      {%- for contact in contacts %}
       {
-        "name": "{{ contact_name }}",
-        "organization": "{{ contact_institution }}",
+        "name": "{{ contact.name }}",
+        "organization": "{{ contact.institution }}",
         "email": [
-          {"value" : "{{ contact_email }}"}
+          {"value" : "{{ contact.email }}"}
         ]
       }
+      {%- endfor %}
     ],
     "themes": [
+      {%- for theme in themes %}
       {
-        {% for theme in themes %}
         "concepts": [
           {% for concept in theme.concepts %}
           {
-            "id": "{{ concept.scheme_concept }}"
+            "id": "{{ concept }}"
           }
           {% endfor %}
         ],
         "scheme": "{{ theme.scheme_url }}"
-        {% endfor %}
       }
+      {%- endfor %}
     ],
     "formats": [
       "CSV",
       "GeoJSON"
     ],
     "license": "{{ license }}",
-    "dataCollectionTool": "{{ dataCollectionTool }}"
+    "dataCollectionTool": "{{ tool }}"
   },
   "links": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "dotmap",
     "nepy",
     "simplekml",
+    "isodate"
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "dotmap",
     "nepy",
     "simplekml",
-    "isodate"
+    "isodate",
+    "jinja2"
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR adds support for easily defining OGC API metadata records directly from a dataset. The new class `DatasetRecord` can be used to initialize all metadata properties which can be directly inferred from the dataset itself. Several other properties specified by the OGC API - Records specification can be added using the `RecordProperties` class.