### PR TITLE
Improve compliance with OGC API features

### DIFF
--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -5,7 +5,7 @@ import pandas as pd
 import geopandas as gpd
 from dotmap import DotMap
 
-from pluma.stream import Stream, StreamType
+from pluma.stream import Stream
 
 
 exclude_devices = ["PupilLabs", "Microphone", "Empatica", "BioData", "UBX"]
@@ -31,8 +31,11 @@ def convert_dataset_to_geoframe(
     for stream in streams_to_export:
         cols = list(streams_to_export[stream].columns)
         for idx, entry in enumerate(cols):
-            if entry not in exclude:
-                cols[idx] = f"{stream}.{entry}"
+            if entry in exclude:
+                continue
+
+            cols[idx] = (stream if entry.lower() == "data" else
+                         f"{stream}_{entry}").lower()
         streams_to_export[stream].columns = cols
         out_columns.append(streams_to_export[stream].drop(exclude, axis=1))
     out = out.join(out_columns)
@@ -93,5 +96,5 @@ def recursive_resample_stream(acc_dict, stream, sampling_dt):
         print(type(stream))
 
     if ret is not None:
-        acc_dict[f"{stream.device}.{stream.streamlabel}"] = ret
+        acc_dict[f"{stream.device}_{stream.streamlabel}"] = ret
     return ret

--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -47,6 +47,7 @@ def convert_dataset_to_geoframe(
         y=out['Latitude'],
         z=out['Elevation'])
     out = gpd.GeoDataFrame(out.drop(exclude, axis=1), geometry=geometry)
+    out.crs = 'epsg:4326'
     return out
 
 def export_dataset_to_geojson(

--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -7,6 +7,7 @@ import pandas as pd
 from typing import Union, Optional, Callable, Dict
 
 from pluma.stream import Stream, StreamType
+from pluma.stream.harp import HarpStream
 
 import pluma.preprocessing.resampling as resampling
 
@@ -73,24 +74,24 @@ def resample_stream_accelerometer(stream: Stream,
                                   **kwargs) -> pd.DataFrame:
     check_stream_data_integrity(stream)
     col_sampler = {
-        'Orientation.X': resampling.resample_temporospatial_circ,
-        'Orientation.Y': resampling.resample_temporospatial_circ,
-        'Orientation.Z': resampling.resample_temporospatial_circ,
-        'Gyroscope.X': resampling.resample_temporospatial,
-        'Gyroscope.Y': resampling.resample_temporospatial,
-        'Gyroscope.Z': resampling.resample_temporospatial,
-        'LinearAccl.X': resampling.resample_temporospatial,
-        'LinearAccl.Y': resampling.resample_temporospatial,
-        'LinearAccl.Z': resampling.resample_temporospatial,
-        'Magnetometer.X': resampling.resample_temporospatial,
-        'Magnetometer.Y': resampling.resample_temporospatial,
-        'Magnetometer.Z': resampling.resample_temporospatial,
-        'Accl.X': resampling.resample_temporospatial,
-        'Accl.Y': resampling.resample_temporospatial,
-        'Accl.Z': resampling.resample_temporospatial,
-        'Gravity.X': resampling.resample_temporospatial,
-        'Gravity.Y': resampling.resample_temporospatial,
-        'Gravity.Z': resampling.resample_temporospatial}
+        'Orientation_X': resampling.resample_temporospatial_circ,
+        'Orientation_Y': resampling.resample_temporospatial_circ,
+        'Orientation_Z': resampling.resample_temporospatial_circ,
+        'Gyroscope_X': resampling.resample_temporospatial,
+        'Gyroscope_Y': resampling.resample_temporospatial,
+        'Gyroscope_Z': resampling.resample_temporospatial,
+        'LinearAccl_X': resampling.resample_temporospatial,
+        'LinearAccl_Y': resampling.resample_temporospatial,
+        'LinearAccl_Z': resampling.resample_temporospatial,
+        'Magnetometer_X': resampling.resample_temporospatial,
+        'Magnetometer_Y': resampling.resample_temporospatial,
+        'Magnetometer_Z': resampling.resample_temporospatial,
+        'Accl_X': resampling.resample_temporospatial,
+        'Accl_Y': resampling.resample_temporospatial,
+        'Accl_Z': resampling.resample_temporospatial,
+        'Gravity_X': resampling.resample_temporospatial,
+        'Gravity_Y': resampling.resample_temporospatial,
+        'Gravity_Z': resampling.resample_temporospatial}
     georef = _get_georef(stream)
     resampled_data = {k: resampling_method(stream.data[k], georef, sampling_dt)
                       for k, resampling_method in col_sampler.items()


### PR DESCRIPTION
Ensure exporting the dataset as a `GeoDataFrame` follows OGC API naming conventions, specifically ensuring the CRS is included whenever it is available and using a snake case naming style for data attributes.