### PR TITLE
Improve compatibility of frame column naming conventions

### DIFF
--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -94,5 +94,8 @@ def recursive_resample_stream(acc_dict, stream, sampling_dt):
         print(type(stream))
 
     if ret is not None:
-        acc_dict[f"{stream.device}_{stream.streamlabel}"] = ret
+        acc_key = stream.device
+        if stream.streamlabel != acc_key:
+            acc_key = f"{acc_key}_{stream.streamlabel}" 
+        acc_dict[acc_key] = ret
     return ret

--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -86,12 +86,10 @@ def recursive_resample_stream(acc_dict, stream, sampling_dt):
         if stream.device not in exclude_devices:
             try:
                 ret = stream.resample(sampling_dt)
-            except NotImplementedError as E:
+            except NotImplementedError:
                 pass
-            except:
-                print(f"Failed Stream {stream}")
-        else:
-            pass
+            except Exception as E:
+                print(f"Failed Stream {stream}: {E}")
     else:
         print(type(stream))
 

--- a/pluma/io/accelerometer.py
+++ b/pluma/io/accelerometer.py
@@ -8,12 +8,12 @@ from pluma.io.harp import _HARP_T0
 from pluma.io.path_helper import ComplexPath, ensure_complexpath
 
 _accelerometer_header = [
-    'Orientation.X', 'Orientation.Y', 'Orientation.Z',
-    'Gyroscope.X', 'Gyroscope.Y', 'Gyroscope.Z',
-    'LinearAccl.X', 'LinearAccl.Y', 'LinearAccl.Z',
-    'Magnetometer.X', 'Magnetometer.Y', 'Magnetometer.Z',
-    'Accl.X', 'Accl.Y', 'Accl.Z',
-    'Gravity.X', 'Gravity.Y', 'Gravity.Z',
+    'Orientation_X', 'Orientation_Y', 'Orientation_Z',
+    'Gyroscope_X', 'Gyroscope_Y', 'Gyroscope_Z',
+    'LinearAccl_X', 'LinearAccl_Y', 'LinearAccl_Z',
+    'Magnetometer_X', 'Magnetometer_Y', 'Magnetometer_Z',
+    'Accl_X', 'Accl_Y', 'Accl_Z',
+    'Gravity_X', 'Gravity_Y', 'Gravity_Z',
     'SysCalibEnabled', 'GyroCalibEnabled',
     'AccCalibEnabled', 'MagCalibEnabled',
     'Temperature', 'Seconds', 'SoftwareTimestamp']


### PR DESCRIPTION
To avoid conflicting dot notation with JSON objects, data frame column names have been renamed to use `_` as hierarchy separator. The exported geoframe also avoids duplicating stream labels in cases where the device name is the same.