### PR TITLE
Remove redundant self-links

### DIFF
--- a/pluma/templates/metadata_template.j2
+++ b/pluma/templates/metadata_template.j2
@@ -54,18 +54,6 @@
   },
   "links": [
     {
-      "rel": "alternate",
-      "type": "text/html",
-      "title": "This document as HTML",
-      "href": "https://emotional.byteroad.net/collections/ec_catalog/{{ id }}"
-    },
-    {
-      "rel": "alternate",
-      "type": "application/geo+json",
-      "title": "This document as GeoJSON",
-      "href": "https://emotional.byteroad.net/collections/ec_catalog/{{ id }}?f=json"
-    },
-    {
       "rel": "item",
       "type": "image/png",
       "title": "OGC Web Map Service (WMS)",


### PR DESCRIPTION
This PR removes the first two self-reference links from the JSON metadata template. The format specification was incorrect and they are added automatically by the hosting service, so better to leave them undefined.