### PR TITLE
 Add new streams, io and schema for VR experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.pyc
 *.egg-info
 dist
+.idea/

--- a/pluma/io/glia.py
+++ b/pluma/io/glia.py
@@ -9,41 +9,43 @@ from pluma.io.path_helper import ComplexPath, ensure_complexpath
 
 
 def load_glia(filename: str,
-              dtypes: list[chr],
-              channel_names: list[str],
+              dtypes: list[list[chr]],
+              channel_names: list[list[str]],
               root: Union[str, ComplexPath] = ''
               ) -> pd.DataFrame:
 
     path = ensure_complexpath(root)
-    path.join(filename)
+    path.join(filename+'_Frame1.bin')
 
-    df = pd.DataFrame(columns=channel_names)
+    df_timestamps = pd.DataFrame(columns=channel_names[0])
+    df_data = pd.DataFrame(columns=channel_names[1])
 
     try:
-        header = ''
-        with path.open('rb') as stream:
-            # we first need to find the header string for this glia stream
-            decoded = ''
-            while decoded != '\x00':
-                header += decoded
-                chunk = stream.read(struct.calcsize('1s'))
-                decoded = chunk.decode()
-
-        header_bytes = len(header)
-        separator_bytes = 1
-        data_bytes = sum([struct.calcsize(f) for f in dtypes])
-        format_string = ''.join(dtypes)
-
+        # unpack timestamps
+        data_bytes = sum([struct.calcsize(f) for f in dtypes[0]])
+        format_string = ''.join(dtypes[0])
         with path.open('rb') as stream:
             while True:
-                header_chunk = stream.read(header_bytes + separator_bytes)
-                header_string = header_chunk.decode('unicode-escape')
                 chunk = stream.read(data_bytes)
-                if not header_chunk:
+                if not chunk:
                     break
 
                 unpacked = list(struct.unpack(format_string, chunk))
-                df.loc[len(df.index)] = unpacked
+                df_timestamps.loc[len(df_timestamps.index)] = unpacked
+
+        # unpack data
+        path = ensure_complexpath(root)
+        path.join(filename + '_Frame2.bin')
+        data_bytes = sum([struct.calcsize(f) for f in dtypes[1]])
+        format_string = ''.join(dtypes[1])
+        with path.open('rb') as stream:
+            while True:
+                chunk = stream.read(data_bytes)
+                if not chunk:
+                    break
+
+                unpacked = list(struct.unpack(format_string, chunk))
+                df_data.loc[len(df_data.index)] = unpacked
     except FileNotFoundError:
         warnings.warn(f'Glia stream file\
                 {path} could not be found.')
@@ -51,4 +53,5 @@ def load_glia(filename: str,
         warnings.warn(f'Glia stream file\
                 {path} could not be found.')
 
-    return df
+    return pd.concat([df_timestamps, df_data], axis=1)
+

--- a/pluma/io/glia.py
+++ b/pluma/io/glia.py
@@ -5,47 +5,28 @@ import numpy as np
 from typing import Union
 
 import pandas as pd
-from pluma.io.path_helper import ComplexPath, ensure_complexpath
+import os
+from pluma.io.path_helper import ComplexPath
 
 
 def load_glia(filename: str,
-              dtypes: list[list[chr]],
-              channel_names: list[list[str]],
+              dtypes: list[list[tuple[str, type]]],
               root: Union[str, ComplexPath] = ''
               ) -> pd.DataFrame:
+    path = os.path.join(root._path, filename+'_Frame1.bin')
 
-    path = ensure_complexpath(root)
-    path.join(filename+'_Frame1.bin')
-
-    df_timestamps = pd.DataFrame(columns=channel_names[0])
-    df_data = pd.DataFrame(columns=channel_names[1])
+    df_timestamps = pd.DataFrame(columns=[chan[0] for chan in dtypes[0]])
+    df_data = pd.DataFrame(columns=[chan[0] for chan in dtypes[1]])
 
     try:
         # unpack timestamps
-        data_bytes = sum([struct.calcsize(f) for f in dtypes[0]])
-        format_string = ''.join(dtypes[0])
-        with path.open('rb') as stream:
-            while True:
-                chunk = stream.read(data_bytes)
-                if not chunk:
-                    break
-
-                unpacked = list(struct.unpack(format_string, chunk))
-                df_timestamps.loc[len(df_timestamps.index)] = unpacked
+        t_data = np.fromfile(path, dtype=np.dtype(dtypes[0]))
+        df_timestamps = pd.DataFrame(t_data)
 
         # unpack data
-        path = ensure_complexpath(root)
-        path.join(filename + '_Frame2.bin')
-        data_bytes = sum([struct.calcsize(f) for f in dtypes[1]])
-        format_string = ''.join(dtypes[1])
-        with path.open('rb') as stream:
-            while True:
-                chunk = stream.read(data_bytes)
-                if not chunk:
-                    break
-
-                unpacked = list(struct.unpack(format_string, chunk))
-                df_data.loc[len(df_data.index)] = unpacked
+        path = os.path.join(root._path, filename + '_Frame2.bin')
+        d_data = np.fromfile(path, dtype=np.dtype(dtypes[1]))
+        df_data = pd.DataFrame(d_data)
     except FileNotFoundError:
         warnings.warn(f'Glia stream file\
                 {path} could not be found.')

--- a/pluma/io/glia.py
+++ b/pluma/io/glia.py
@@ -1,0 +1,54 @@
+import struct
+import warnings
+import numpy as np
+
+from typing import Union
+
+import pandas as pd
+from pluma.io.path_helper import ComplexPath, ensure_complexpath
+
+
+def load_glia(filename: str,
+              dtypes: list[chr],
+              channel_names: list[str],
+              root: Union[str, ComplexPath] = ''
+              ) -> pd.DataFrame:
+
+    path = ensure_complexpath(root)
+    path.join(filename)
+
+    df = pd.DataFrame(columns=channel_names)
+
+    try:
+        header = ''
+        with path.open('rb') as stream:
+            # we first need to find the header string for this glia stream
+            decoded = ''
+            while decoded != '\x00':
+                header += decoded
+                chunk = stream.read(struct.calcsize('1s'))
+                decoded = chunk.decode()
+
+        header_bytes = len(header)
+        separator_bytes = 1
+        data_bytes = sum([struct.calcsize(f) for f in dtypes])
+        format_string = ''.join(dtypes)
+
+        with path.open('rb') as stream:
+            while True:
+                header_chunk = stream.read(header_bytes + separator_bytes)
+                header_string = header_chunk.decode('unicode-escape')
+                chunk = stream.read(data_bytes)
+                if not header_chunk:
+                    break
+
+                unpacked = list(struct.unpack(format_string, chunk))
+                df.loc[len(df.index)] = unpacked
+    except FileNotFoundError:
+        warnings.warn(f'Microphone stream file\
+                {path} could not be found.')
+    except FileExistsError:
+        warnings.warn(f'Microphone stream file\
+                {path} could not be found.')
+
+    return df

--- a/pluma/io/glia.py
+++ b/pluma/io/glia.py
@@ -45,10 +45,10 @@ def load_glia(filename: str,
                 unpacked = list(struct.unpack(format_string, chunk))
                 df.loc[len(df.index)] = unpacked
     except FileNotFoundError:
-        warnings.warn(f'Microphone stream file\
+        warnings.warn(f'Glia stream file\
                 {path} could not be found.')
     except FileExistsError:
-        warnings.warn(f'Microphone stream file\
+        warnings.warn(f'Glia stream file\
                 {path} could not be found.')
 
     return df

--- a/pluma/io/glia.py
+++ b/pluma/io/glia.py
@@ -6,26 +6,28 @@ from typing import Union
 
 import pandas as pd
 import os
-from pluma.io.path_helper import ComplexPath
+from pluma.io.path_helper import ComplexPath, ensure_complexpath
 
 
 def load_glia(filename: str,
               dtypes: list[list[tuple[str, type]]],
               root: Union[str, ComplexPath] = ''
               ) -> pd.DataFrame:
-    path = os.path.join(root._path, filename+'_Frame1.bin')
+    path = ensure_complexpath(root)
+    path.join(filename + '_Frame1.bin')
 
     df_timestamps = pd.DataFrame(columns=[chan[0] for chan in dtypes[0]])
     df_data = pd.DataFrame(columns=[chan[0] for chan in dtypes[1]])
 
     try:
         # unpack timestamps
-        t_data = np.fromfile(path, dtype=np.dtype(dtypes[0]))
+        t_data = np.fromfile(path.path, dtype=np.dtype(dtypes[0]))
         df_timestamps = pd.DataFrame(t_data)
 
         # unpack data
-        path = os.path.join(root._path, filename + '_Frame2.bin')
-        d_data = np.fromfile(path, dtype=np.dtype(dtypes[1]))
+        path = ensure_complexpath(root)
+        path.join(filename + '_Frame2.bin')
+        d_data = np.fromfile(path.path, dtype=np.dtype(dtypes[1]))
         df_data = pd.DataFrame(d_data)
     except FileNotFoundError:
         warnings.warn(f'Glia stream file\

--- a/pluma/schema/vr.py
+++ b/pluma/schema/vr.py
@@ -1,0 +1,132 @@
+from dotmap import DotMap
+from typing import Union
+
+from pluma.stream.harp import HarpStream
+from pluma.stream.accelerometer import AccelerometerStream
+from pluma.stream.empatica import EmpaticaStream
+from pluma.stream.ubx import UbxStream, _UBX_MSGIDS
+from pluma.stream.microphone import MicrophoneStream
+from pluma.stream.eeg import EegStream
+from pluma.stream.glia import GliaStream
+
+from pluma.io.path_helper import ComplexPath, ensure_complexpath
+
+
+def build_schema(root: Union[str, ComplexPath],
+                 parent_dataset = None,
+                 autoload: bool = False) -> DotMap:
+    """Builds a stream schema from a predefined structure.
+
+    Args:
+        root (str, optional): Path to the folder containing the full dataset raw data. Defaults to None.
+        autoload (bool, optional): If True it will automatically attempt to load data from disk. Defaults to False.
+
+    Returns:
+        DotMap: DotMap with all the created data streams.
+    """
+    root = ensure_complexpath(root)
+    streams = DotMap()
+
+    # BioData streams
+    streams.BioData.EnableStreams =               HarpStream(32, device='BioData', streamlabel='EnableStreams', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.DisableStreams =              HarpStream(33, device='BioData', streamlabel='DisableStreams', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.ECG =                         HarpStream(35, device='BioData', streamlabel='ECG', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.GSR =                         HarpStream(36, device='BioData', streamlabel='GSR', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.Accelerometer =               HarpStream(37, device='BioData', streamlabel='Accelerometer', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.DigitalIn =                   HarpStream(38, device='BioData', streamlabel='DigitalIn', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.Set =                         HarpStream(39, device='BioData', streamlabel='Set', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.BioData.Clear =                       HarpStream(40, device='BioData', streamlabel='Clear', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # TinkerForge streams
+    streams.TK.AmbientLight.AmbientLight =        HarpStream(223, device='TK', streamlabel='AmbientLight.AmbientLight', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.CO2V2.CO2Conc =                    HarpStream(224, device='TK', streamlabel='CO2V2.CO2Conc', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.CO2V2.Temperature =                HarpStream(225, device='TK', streamlabel='CO2V2.Temperature', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.CO2V2.Humidity =                   HarpStream(226, device='TK', streamlabel='CO2V2.Humidity', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.GPS.Latitude =                     HarpStream(227, device='TK', streamlabel='GPS.Latitude', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.GPS.Longitude =                    HarpStream(228, device='TK', streamlabel='GPS.Longitude', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.GPS.Altitude =                     HarpStream(229, device='TK', streamlabel='GPS.Altitude', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.GPS.Data =                         HarpStream(230, device='TK', streamlabel='GPS.Data', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.GPS.Time =                         HarpStream(231, device='TK', streamlabel='GPS.Time', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.GPS.HasFix =                       HarpStream(232, device='TK', streamlabel='GPS.HasFix', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.AirQuality.IAQIndex =              HarpStream(233, device='TK', streamlabel='AirQuality.IAQIndex', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.AirQuality.Temperature =           HarpStream(234, device='TK', streamlabel='AirQuality.Temperature', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.AirQuality.Humidity =              HarpStream(235, device='TK', streamlabel='AirQuality.Humidity', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.AirQuality.AirPressure =           HarpStream(236, device='TK', streamlabel='AirQuality.AirPressure', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.SoundPressureLevel.SPL =           HarpStream(237, device='TK', streamlabel='SoundPressureLevel.SPL', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.Humidity.Humidity =                HarpStream(238, device='TK', streamlabel='Humidity.Humidity', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.AnalogIn.Voltage =                 HarpStream(239, device='TK', streamlabel='AnalogIn.Voltage', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.ParticulateMatter.PM1_0 =          HarpStream(240, device='TK', streamlabel='ParticulateMatter.PM1_0', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.ParticulateMatter.PM2_5 =          HarpStream(241, device='TK', streamlabel='ParticulateMatter.PM2_5', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.TK.ParticulateMatter.PM10_0 =         HarpStream(242, device='TK', streamlabel='ParticulateMatter.PM10_0', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.Dual0_20mA.SolarLight =      	  HarpStream(243, device='TK', streamlabel='Dual0_20mA.SolarLight', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.Thermocouple.Temperature =      	  HarpStream(244, device='TK', streamlabel='Thermocouple.Temperature', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.TK.PTC.AirTemp =      	  			  HarpStream(245, device='TK', streamlabel='PTC.AirTemp', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # Accelerometer streams
+    streams.Accelerometer =                       AccelerometerStream(device='Accelerometer', streamlabel='Accelerometer', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # # Empatica streams
+    # streams.Empatica =                            EmpaticaStream(device='Empatica', streamlabel='Empatica', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # # Microphone streams
+    # streams.Microphone.Audio =                    MicrophoneStream(device='Microphone', streamlabel='Audio', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    # streams.Microphone.BufferIndex =              HarpStream(222, device='Microphone', streamlabel='BufferIndex', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # # EEG stream
+    # streams.EEG =                                 EegStream(device='Enobio', streamlabel='EEG', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    # Glia streams
+    streams.Glia.EyeTracking.Timestamps =         HarpStream(215, device='Glia', streamlabel='Glia.EyeTracking.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Glia.EyeTracking.Data =               GliaStream('Glia/EyeTracking.bin',
+                                                             ['q', 'q', 'q', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f'],
+                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "CombinedGaze.X", "CombinedGaze.Y", "CombinedGaze.Z",
+                                                              "LeftOpenness", "LeftOpennessConfidence", "LeftDilation", "LeftDilationConfidence", "LeftPosition.X", "LeftPosition.Y",
+                                                              "RightOpenness", "RightOpennessConfidence", "RightDilation", "RightDilationConfidence", "RightPosition.X", "RightPosition.Y"],
+                                                             device='Glia',
+                                                             streamlabel='Glia.EyeTracking.Data',
+                                                             root=root, autoload=autoload,
+                                                             parent_dataset=parent_dataset)
+
+    streams.Glia.HeartRate.Timestamps =           HarpStream(216, device='Glia', streamlabel='Glia.HeartRate.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Glia.HeartRate.Data =                 GliaStream('Glia/HeartRate.bin',
+                                                             ['q', 'q', 'q', 'I'],
+                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "HeartRate"],
+                                                             device='Glia',
+                                                             streamlabel='Glia.HeartRate.Data',
+                                                             root=root, autoload=autoload,
+                                                             parent_dataset=parent_dataset)
+
+    streams.Glia.IMU.Timestamps =                 HarpStream(217, device='Glia', streamlabel='Glia.IMU.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Glia.IMU.Data =                       GliaStream('Glia/IMU.bin',
+                                                             ['q', 'q', 'q', 'f', 'f', 'f', 'f', 'f', 'f'],
+                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "AccelX", "AccelY", "AccelZ", "GyroX", "GyroY", "GyroZ"],
+                                                             device='Glia',
+                                                             streamlabel='Glia.IMU.Data',
+                                                             root=root, autoload=autoload,
+                                                             parent_dataset=parent_dataset)
+
+    streams.Glia.Mouth.Timestamp =                HarpStream(218, device='Glia', streamlabel='Glia.Mouth.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.Unity.Transform.Timestamp =           HarpStream(219, device='Unity', streamlabel='Unity.Transform.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Unity.Transform.Data =                GliaStream('VRTransform.bin',
+                                                             ['q', 'f', 'f', 'f', 'f', 'f', 'f'],
+                                                             ["Timestamp", "Transform.Position.X", "Transform.Position.Y", "Transform.Position.Z",
+                                                              "Transform.Forward.X", "Transform.Forward.Y", "Transform.Forward.Z"],
+                                                             device='Unity',
+                                                             streamlabel='Unity.Transform.Data',
+                                                             root=root, autoload=autoload,
+                                                             parent_dataset=parent_dataset)
+
+    streams.Unity.Video.Timestamp =               HarpStream(220, device='Unity', streamlabel='Unity.Video.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    return streams

--- a/pluma/schema/vr.py
+++ b/pluma/schema/vr.py
@@ -88,10 +88,10 @@ def build_schema(root: Union[str, ComplexPath],
     # Glia streams
     streams.Glia.EyeTracking.Timestamps =         HarpStream(215, device='Glia', streamlabel='Glia.EyeTracking.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
     streams.Glia.EyeTracking.Data =               GliaStream('Glia/EyeTracking.bin',
-                                                             ['q', 'q', 'q', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f'],
-                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "CombinedGaze.X", "CombinedGaze.Y", "CombinedGaze.Z",
+                                                             [['Q', 'Q', 'Q'], ['f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f']],
+                                                             [["HardwareTime", "OmniceptTime", "SystemTime"],  ["CombinedGaze.X", "CombinedGaze.Y", "CombinedGaze.Z",
                                                               "LeftOpenness", "LeftOpennessConfidence", "LeftDilation", "LeftDilationConfidence", "LeftPosition.X", "LeftPosition.Y",
-                                                              "RightOpenness", "RightOpennessConfidence", "RightDilation", "RightDilationConfidence", "RightPosition.X", "RightPosition.Y"],
+                                                              "RightOpenness", "RightOpennessConfidence", "RightDilation", "RightDilationConfidence", "RightPosition.X", "RightPosition.Y"]],
                                                              device='Glia',
                                                              streamlabel='Glia.EyeTracking.Data',
                                                              root=root, autoload=autoload,
@@ -99,8 +99,8 @@ def build_schema(root: Union[str, ComplexPath],
 
     streams.Glia.HeartRate.Timestamps =           HarpStream(216, device='Glia', streamlabel='Glia.HeartRate.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
     streams.Glia.HeartRate.Data =                 GliaStream('Glia/HeartRate.bin',
-                                                             ['q', 'q', 'q', 'I'],
-                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "HeartRate"],
+                                                             [['Q', 'Q', 'Q'], ['I']],
+                                                             [["HardwareTime", "OmniceptTime", "SystemTime"], ["HeartRate"]],
                                                              device='Glia',
                                                              streamlabel='Glia.HeartRate.Data',
                                                              root=root, autoload=autoload,
@@ -108,25 +108,49 @@ def build_schema(root: Union[str, ComplexPath],
 
     streams.Glia.IMU.Timestamps =                 HarpStream(217, device='Glia', streamlabel='Glia.IMU.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
     streams.Glia.IMU.Data =                       GliaStream('Glia/IMU.bin',
-                                                             ['q', 'q', 'q', 'f', 'f', 'f', 'f', 'f', 'f'],
-                                                             ["HardwareTime", "OmniceptTime", "SystemTime", "AccelX", "AccelY", "AccelZ", "GyroX", "GyroY", "GyroZ"],
+                                                             [['Q', 'Q', 'Q'], ['f', 'f', 'f', 'f', 'f', 'f']],
+                                                             [["HardwareTime", "OmniceptTime", "SystemTime"], ["AccelX", "AccelY", "AccelZ", "GyroX", "GyroY", "GyroZ"]],
                                                              device='Glia',
                                                              streamlabel='Glia.IMU.Data',
                                                              root=root, autoload=autoload,
                                                              parent_dataset=parent_dataset)
 
-    streams.Glia.Mouth.Timestamp =                HarpStream(218, device='Glia', streamlabel='Glia.Mouth.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Glia.Mouth.Timestamps =                HarpStream(218, device='Glia', streamlabel='Glia.Mouth.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
 
-    streams.Unity.Transform.Timestamp =           HarpStream(219, device='Unity', streamlabel='Unity.Transform.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
-    streams.Unity.Transform.Data =                GliaStream('VRTransform.bin',
-                                                             ['q', 'f', 'f', 'f', 'f', 'f', 'f'],
-                                                             ["Timestamp", "Transform.Position.X", "Transform.Position.Y", "Transform.Position.Z",
-                                                              "Transform.Forward.X", "Transform.Forward.Y", "Transform.Forward.Z"],
-                                                             device='Unity',
-                                                             streamlabel='Unity.Transform.Data',
-                                                             root=root, autoload=autoload,
-                                                             parent_dataset=parent_dataset)
+    streams.Unity.Transform.Timestamps =           HarpStream(219, device='Unity', streamlabel='Unity.Transform.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Unity.Transform.Data =                 GliaStream('VRTransform/Position.bin',
+                                                              [['Q'], ['f', 'f', 'f', 'f', 'f', 'f']],
+                                                              [["Timestamp"], ["Transform.Position.X", "Transform.Position.Y", "Transform.Position.Z",
+                                                               "Transform.Forward.X", "Transform.Forward.Y", "Transform.Forward.Z"]],
+                                                              device='Unity',
+                                                              streamlabel='Unity.Transform.Data',
+                                                              root=root, autoload=autoload,
+                                                              parent_dataset=parent_dataset)
 
-    streams.Unity.Video.Timestamp =               HarpStream(220, device='Unity', streamlabel='Unity.Video.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Unity.Video.Timestamps =               HarpStream(220, device='Unity', streamlabel='Unity.Video.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+
+    streams.Unity.PointToOriginWorld.Timestamps =  HarpStream(227, device='Unity', streamlabel='Unity.PointToOriginWorld.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Unity.PointToOriginWorld.Data =        GliaStream('Unity_PointToOriginWorld/PointToOriginWorld.bin',
+                                                              [['Q'], ['f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f']],
+                                                              [["Timestamp"], ["Origin.Position.X", "Origin.Position.Y", "Origin.Position.Z",
+                                                               "Hand.Position.X", "Hand.Position.Y", "Hand.Position.Z",
+                                                               "HandAxis.Angle.X", "HandAxis.Angle.Y", "HandAxis.Angle.Z",
+                                                               "OriginAxis.Angle.X", "OriginAxis.Angle.Y", "OriginAxis.Angle.Z"]],
+                                                              device='Unity',
+                                                              streamlabel='Unity.PointToOriginWorld.Data',
+                                                              root=root, autoload=autoload,
+                                                              parent_dataset=parent_dataset)
+
+    streams.Unity.PointToOriginMap.Timestamps =    HarpStream(228, device='Unity', streamlabel='Unity.PointToOriginMap.Timestamps', root=root, autoload=autoload, parent_dataset=parent_dataset)
+    streams.Unity.PointToOriginMap.Data =          GliaStream('Unity_PointToOriginMap/PointToOriginMap.bin',
+                                                              [['Q'], ['f', 'f', 'f', 'f', 'f', 'f']],
+                                                              [["Timestamp"], ["Origin.Position.X", "Origin.Position.Y",
+                                                               "Subject.Position.X", "Subject.Position.Y",
+                                                               "Point.Position.X", "Point.Position.Y"]],
+                                                              device='Unity',
+                                                              streamlabel='Unity.PointToOriginMap.Data',
+                                                              root=root, autoload=autoload,
+                                                              parent_dataset=parent_dataset)
 
     return streams
+

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -15,6 +15,7 @@ class StreamType(Enum):
 	EMPATICA = 'EmpaticaStream'
 	EEG = 'EegStream'
 	GLIA = 'GliaStream'
+	CSV = 'CsvStream'
 
 
 class Stream:

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -14,6 +14,7 @@ class StreamType(Enum):
 	MICROPHONE = 'MicrophoneStream'
 	EMPATICA = 'EmpaticaStream'
 	EEG = 'EegStream'
+	GLIA = 'GliaStream'
 
 
 class Stream:

--- a/pluma/stream/csv.py
+++ b/pluma/stream/csv.py
@@ -11,7 +11,7 @@ from pluma.io.path_helper import ensure_complexpath
 class CsvStream(Stream):
     def __init__(self,
                  filename: str,
-                 data: np.array = np.empty(shape=(0, 1)),
+                 data: pd.DataFrame = None,
                  si_conversion: SiUnitConversion = SiUnitConversion(),
                  clockreferenceid: ClockRefId = ClockRefId.HARP,
                  **kw):
@@ -42,5 +42,5 @@ class CsvStream(Stream):
     def convert_to_si(self, data=None):
         pass
 
-    def export_to_csv(self):
-        pass
+    def export_to_csv(self, export_path):
+        self.data.to_csv(export_path)

--- a/pluma/stream/csv.py
+++ b/pluma/stream/csv.py
@@ -1,0 +1,46 @@
+import numpy as np
+import os
+import pandas as pd
+import warnings
+from pluma.stream import Stream, StreamType
+from pluma.stream.siconversion import SiUnitConversion
+from pluma.sync import ClockRefId
+from pluma.io.path_helper import ensure_complexpath
+
+
+class CsvStream(Stream):
+    def __init__(self,
+                 filename: str,
+                 data: np.array = np.empty(shape=(0, 1)),
+                 si_conversion: SiUnitConversion = SiUnitConversion(),
+                 clockreferenceid: ClockRefId = ClockRefId.HARP,
+                 **kw):
+        super(CsvStream, self).__init__(data=data, **kw)
+        self.streamtype = StreamType.CSV
+        self.filename = filename
+        self.si_conversion = si_conversion
+        self.clockreference.referenceid = clockreferenceid
+
+        if self.autoload:
+            self.load()
+
+    def load(self):
+        path = ensure_complexpath(self.rootfolder)._path
+        path = os.path.join(path, self.filename)
+        try:
+            self.data = pd.read_csv(path)
+        except FileNotFoundError:
+            warnings.warn(f'Glia stream file\
+                        {path} could not be found.')
+        except FileExistsError:
+            warnings.warn(f'Glia stream file\
+                        {path} could not be found.')
+
+    def resample(self):
+        pass
+
+    def convert_to_si(self, data=None):
+        pass
+
+    def export_to_csv(self):
+        pass

--- a/pluma/stream/csv.py
+++ b/pluma/stream/csv.py
@@ -25,10 +25,10 @@ class CsvStream(Stream):
             self.load()
 
     def load(self):
-        path = ensure_complexpath(self.rootfolder)._path
-        path = os.path.join(path, self.filename)
+        path = ensure_complexpath(self.rootfolder)
+        path.join(self.filename)
         try:
-            self.data = pd.read_csv(path)
+            self.data = pd.read_csv(path.path)
         except FileNotFoundError:
             warnings.warn(f'Glia stream file\
                         {path} could not be found.')

--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -9,14 +9,14 @@ from pluma.sync import ClockRefId
 class GliaStream(Stream):
     def __init__(self,
                  filename: str,
-                 dtypes: list[chr],
-                 channel_names: list[str],
+                 dtypes: list[list[chr]],  # list of list of char formats within each frame after topic
+                 channel_names: list[list[str]],  # list of list of string channel names within each frame after topic
                  data: np.array = np.empty(shape=(0, 1)),
                  si_conversion: SiUnitConversion = SiUnitConversion(),
                  clockreferenceid: ClockRefId = ClockRefId.HARP,
                  **kw):
         super(GliaStream, self).__init__(data=data, **kw)
-        self.streamtype = StreamType.GLIA
+        self.streamtype = 'Glia'  # TODO this should be a defined stream type in pluma analysis
         self.filename = filename
         self.dtypes = dtypes
         self.channel_names = channel_names

--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -16,7 +16,7 @@ class GliaStream(Stream):
                  clockreferenceid: ClockRefId = ClockRefId.HARP,
                  **kw):
         super(GliaStream, self).__init__(data=data, **kw)
-        self.streamtype = 'Glia'  # TODO this should be a defined stream type in pluma analysis
+        self.streamtype = StreamType.GLIA
         self.filename = filename
         self.dtypes = dtypes
         self.channel_names = channel_names

--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from pluma.stream import Stream, StreamType
+from pluma.stream.siconversion import SiUnitConversion
+from pluma.io.glia import load_glia
+from pluma.sync import ClockRefId
+
+
+class GliaStream(Stream):
+    def __init__(self,
+                 filename: str,
+                 dtypes: list[chr],
+                 channel_names: list[str],
+                 data: np.array = np.empty(shape=(0, 1)),
+                 si_conversion: SiUnitConversion = SiUnitConversion(),
+                 clockreferenceid: ClockRefId = ClockRefId.HARP,
+                 **kw):
+        super(GliaStream, self).__init__(data=data, **kw)
+        self.streamtype = 'Glia'  # TODO this should be a defined stream type in pluma analysis
+        self.filename = filename
+        self.dtypes = dtypes
+        self.channel_names = channel_names
+        self.si_conversion = si_conversion
+        self.clockreference.referenceid = clockreferenceid
+
+        assert(len(self.dtypes) == len(self.channel_names)), "Number of data types does not match number of channel names."
+
+        if self.autoload:
+            self.load()
+
+    def load(self):
+        self.data = load_glia(self.filename, self.dtypes, self.channel_names, root=self.rootfolder)
+
+    def resample(self):
+        pass
+
+    def convert_to_si(self, data=None):
+        pass
+
+    def export_to_csv(self):
+        pass

--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -1,16 +1,18 @@
 import numpy as np
+import pandas as pd
 
 from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.io.glia import load_glia
 from pluma.sync import ClockRefId
+from pluma.export.streams import export_stream_to_csv
 
 
 class GliaStream(Stream):
     def __init__(self,
                  filename: str,
                  dtypes: list[list[tuple[str, type]]],
-                 data: np.array = np.empty(shape=(0, 1)),
+                 data: pd.DataFrame = None,
                  si_conversion: SiUnitConversion = SiUnitConversion(),
                  clockreferenceid: ClockRefId = ClockRefId.HARP,
                  **kw):
@@ -33,5 +35,5 @@ class GliaStream(Stream):
     def convert_to_si(self, data=None):
         pass
 
-    def export_to_csv(self):
-        pass
+    def export_to_csv(self, export_path):
+        self.data.to_csv(export_path)

--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -9,8 +9,7 @@ from pluma.sync import ClockRefId
 class GliaStream(Stream):
     def __init__(self,
                  filename: str,
-                 dtypes: list[list[chr]],  # list of list of char formats within each frame after topic
-                 channel_names: list[list[str]],  # list of list of string channel names within each frame after topic
+                 dtypes: list[list[tuple[str, type]]],
                  data: np.array = np.empty(shape=(0, 1)),
                  si_conversion: SiUnitConversion = SiUnitConversion(),
                  clockreferenceid: ClockRefId = ClockRefId.HARP,
@@ -19,17 +18,14 @@ class GliaStream(Stream):
         self.streamtype = StreamType.GLIA
         self.filename = filename
         self.dtypes = dtypes
-        self.channel_names = channel_names
         self.si_conversion = si_conversion
         self.clockreference.referenceid = clockreferenceid
-
-        assert(len(self.dtypes) == len(self.channel_names)), "Number of data types does not match number of channel names."
 
         if self.autoload:
             self.load()
 
     def load(self):
-        self.data = load_glia(self.filename, self.dtypes, self.channel_names, root=self.rootfolder)
+        self.data = load_glia(self.filename, self.dtypes, root=self.rootfolder)
 
     def resample(self):
         pass


### PR DESCRIPTION
This PR adds a new stream class: GliaStream which allows a dataset to read Unity data streams for pluma VR experiments.

These streams are usually transmitted from Unity to Bonsai via 0MQ, and then logged as individual 0MQ messages and ~~serialized into a binary file as sequences of messages containing a null terminated string specifying the sensor name followed by the data payload~~ serialized into several frames containing (in order) message topic (i.e. sensor); timestamps; data payload. The GliaStream class can be used to read any streams of this kind by providing format labels ~~as a char array input argument. The format characters follow the python struct convention detailed here https://docs.python.org/3/library/struct.html#format-characters~~ as lists of tuples with the form ('channel_name', dtype) where dtype follows the numpy convention detailed here: https://numpy.org/doc/stable/user/basics.types.html

This PR also adds a new schema (vr) that defines a pluma VR dataset with these Unity streams; and a generic CSV stream reader for data that is already in CSV format.