### PR TITLE
Externalize clock calibration diagnosis plot

### DIFF
--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -225,9 +225,9 @@ class Dataset:
         fig = maps.showmap(temp_df, **kwargs)
         return fig
 
-    def add_georeference_and_calibrate(self):
+    def add_georeference_and_calibrate(self, plot_diagnosis=True):
         if self.has_calibration is False:
-            self.calibrate_ubx_to_harp(plot_diagnosis=True, dt_error=1)
+            self.calibrate_ubx_to_harp(plot_diagnosis=plot_diagnosis, dt_error=1)
             self.add_ubx_georeference(event=_UBX_MSGIDS.NAV_HPPOSLLH,
                                     calibrate_clock=True)
             self.has_calibration = True

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -8,7 +8,7 @@ from typing import Union, Optional, Callable
 
 from pluma.schema.outdoor import build_schema
 
-from pluma.sync.ubx2harp import get_clockcalibration_ubx_to_harp_clock
+from pluma.sync.ubx2harp import SyncLookup, get_clockcalibration_model, get_clockcalibration_lookup
 from pluma.sync import ClockRefId
 
 from pluma.stream import StreamType, Stream
@@ -46,7 +46,7 @@ class Dataset:
 
     def add_ubx_georeference(self,
                              ubxstream: UbxStream = None,
-                             event: str = "NAV-HPPOSLLH",
+                             event: str = _UBX_MSGIDS.NAV_HPPOSLLH,
                              calibrate_clock: bool = True,
                              strip=True):
         """_summary_
@@ -192,7 +192,7 @@ class Dataset:
     def calibrate_ubx_to_harp(self,
                               dt_error: float = 0.002,
                               plot_diagnosis: bool = False,
-                              r2_min_qc: float = 0.99):
+                              r2_min_qc: float = 0.99) -> SyncLookup:
         """Attempts to calibrate the ubx clock to harp clock using\
             the synchronization pulses as a reference.
 
@@ -206,17 +206,23 @@ class Dataset:
                 results from an automatic correction procedure. Defaults to 0.99.
         """
 
-        model = get_clockcalibration_ubx_to_harp_clock(
-                ubx_stream=self.streams.UBX,
-                harp_sync=self.streams.BioData.Set.data,
-                dt_error=dt_error,
-                r2_min_qc=r2_min_qc,
-                plot_diagnosis=plot_diagnosis)
+        sync_lookup = get_clockcalibration_lookup(
+            ubx_stream=self.streams.UBX,
+            harp_sync=self.streams.BioData.Set.data,
+            dt_error=dt_error,
+            plot_diagnosis=plot_diagnosis
+        )
+
+        model = get_clockcalibration_model(
+            sync_lookup=sync_lookup,
+            r2_min_qc=r2_min_qc
+        )
 
         self.streams.UBX.clockreference.set_conversion_model(
             model=model,
             reference_from=ClockRefId.HARP)
         self.has_calibration = True
+        return sync_lookup
 
     def showmap(self, **kwargs):
         """Overload to export.showmap that shows spatial information color-coded by time.

--- a/pluma/sync/plotting.py
+++ b/pluma/sync/plotting.py
@@ -1,0 +1,39 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.ticker import MaxNLocator
+from pluma.sync.ubx2harp import SyncTimestamp
+
+def plot_clockcalibration_diagnosis(
+        ubx_ts: SyncTimestamp,
+        harp_ts: SyncTimestamp,
+        pulses_lookup: np.ndarray,
+        axes: tuple[Axes] = None):
+    if axes is None:
+        fig = plt.figure(figsize=(12, 8))
+        idx_ax = fig.add_subplot(211)
+        scatter_ax = fig.add_subplot(212)
+    else:
+        idx_ax = axes[0]
+        scatter_ax = axes[1]
+
+    idx_ax.plot(pulses_lookup[:, 0], pulses_lookup[:, 1], '.')
+    idx_ax.set_xlabel('ubx_index')
+    idx_ax.set_ylabel('Harp_index')
+    idx_ax.set_title('Index correspondence between streams')
+
+    scatter_ax.scatter(
+        np.arange(len(ubx_ts.ts_array[pulses_lookup[:, 0]])-1),
+        np.diff(ubx_ts.ts_array[pulses_lookup[:, 0]]),
+        100, label="ubx")
+    scatter_ax.scatter(
+        np.arange(len(harp_ts.ts_array[pulses_lookup[:, 1]])-1),
+        np.diff(harp_ts.ts_array[pulses_lookup[:, 1]]),
+        label="HARP")
+
+    scatter_ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    scatter_ax.set_ylabel('$\Delta t$ (s)')
+    scatter_ax.set_xlabel('Trial number')
+    scatter_ax.legend()
+    if axes is None:
+        plt.show()

--- a/pluma/sync/ubx2harp.py
+++ b/pluma/sync/ubx2harp.py
@@ -129,7 +129,7 @@ def align_ubx_to_harp(
 
     return pulses_lookup
 
-def get_clockcalibration_ubx_to_harp_lookup(
+def get_clockcalibration_lookup(
         ubx_stream: UbxStream,
         harp_sync: HarpStream,
         dt_error: float = 0.002,
@@ -166,18 +166,9 @@ def get_clockcalibration_ubx_to_harp_lookup(
                                      plot_diagnosis=plot_diagnosis)
     return SyncLookup(ubx_ts, harp_ts, align_lookup)
 
-def get_clockcalibration_ubx_to_harp_clock(ubx_stream: UbxStream,
-                                           harp_sync: HarpStream,
-                                           dt_error: float = 0.002,
-                                           plot_diagnosis: bool = False,
-                                           r2_min_qc: float = 0.99) -> LinearRegression:
+def get_clockcalibration_model(sync_lookup: SyncLookup,
+                               r2_min_qc: float = 0.99) -> LinearRegression:
     
-    sync_lookup = get_clockcalibration_ubx_to_harp_lookup(
-        ubx_stream=ubx_stream,
-        harp_sync=harp_sync,
-        dt_error=dt_error,
-        plot_diagnosis=plot_diagnosis
-    )
     ubx_ts = sync_lookup.ubx_ts
     harp_ts = sync_lookup.harp_ts
     align_lookup = sync_lookup.align_lookup

--- a/pluma/sync/ubx2harp.py
+++ b/pluma/sync/ubx2harp.py
@@ -1,14 +1,9 @@
 import numpy as np
 from dataclasses import dataclass
-import matplotlib.pyplot as plt
-
-from matplotlib.ticker import MaxNLocator
-
 from sklearn.linear_model import LinearRegression
 
 from pluma.stream.harp import HarpStream
 from pluma.stream.ubx import UbxStream, _UBX_MSGIDS, _UBX_CLASSES
-
 
 class SyncTimestamp:
     def __init__(self,
@@ -126,30 +121,11 @@ def align_ubx_to_harp(
         min_pair_index = dyad[1]
 
     if plot_diagnosis is True:
-        plt.figure(figsize=(12, 8))
-        plt.subplot(211)
-        plt.plot(pulses_lookup[:, 0], pulses_lookup[:, 1], '.')
-        plt.xlabel('ubx_index')
-        plt.ylabel('Harp_index')
-        plt.title('Index correspondence between streams')
-
-        plt.subplot(212)
-
-        plt.scatter(
-            np.arange(len(ubx_ts.ts_array[pulses_lookup[:, 0]])-1),
-            np.diff(ubx_ts.ts_array[pulses_lookup[:, 0]]),
-            100, label="ubx")
-        plt.scatter(
-            np.arange(len(harp_ts.ts_array[pulses_lookup[:, 1]])-1),
-            np.diff(harp_ts.ts_array[pulses_lookup[:, 1]]),
-            label="HARP")
-
-        ax = plt.gca()
-        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
-        plt.ylabel('$\Delta t$ (s)')
-        plt.xlabel('Trial number')
-        plt.legend()
-        plt.show()
+        import pluma.sync.plotting as plotting
+        plotting.plot_clockcalibration_diagnosis(
+            ubx_ts=ubx_ts,
+            harp_ts=harp_ts,
+            pulses_lookup=pulses_lookup)
 
     return pulses_lookup
 


### PR DESCRIPTION
This PR externalizes the clock calibration diagnosis plot, to allow customizing figure sizes and axes. Intermediate data structures can be extracted from the low-level calibration routines to provide the required data for custom plotting layouts.