### PR TITLE
Allow custom formatting of map colorbar

### DIFF
--- a/pluma/export/maps.py
+++ b/pluma/export/maps.py
@@ -18,7 +18,7 @@ def showmap(NavData,
             cmap='jet',
             markersize=15,
             colorscale_override=None,
-            **figkwargs):
+            **cbarkwargs):
 
     if 'Data' not in NavData.columns:
         raise ValueError(
@@ -61,7 +61,7 @@ def showmap(NavData,
         cmap=cmap)
     divider = make_axes_locatable(ax)
     cax = divider.append_axes("right", size="5%", pad=0.05)
-    fig.colorbar(im, cax=cax)
+    fig.colorbar(im, cax=cax, **cbarkwargs)
     return fig
 
 


### PR DESCRIPTION
Being able to format the custom colorbar in `showmaps` is useful for specific data types such as dates and times. This PR forwards the `kwargs` of `showmaps` to the `colorbar` call to allow this.