### PR TITLE
Ensure microphone clock reference is set to none

### DIFF
--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -28,7 +28,7 @@ class Stream:
               streamlabel: str,
               root: Union[str, ComplexPath] = '',
               data: any = None,
-              clockreference: ClockReference=ClockReference(referenceid=ClockRefId.NONE),
+              clockreference: ClockReference = None,
 			  parent_dataset=None,
 			  autoload: bool = True):
 		"""_summary_
@@ -39,6 +39,9 @@ class Stream:
 			data (any, optional): Data to initially populate the stream. Defaults to None.
    			autoload (bool, optional): If True, it will attempt to automatically load the data when instantiated. Defaults to True.
 		"""
+
+		if clockreference is None:
+			clockreference = ClockReference(referenceid=ClockRefId.NONE)
 
 		self.device = device
 		self.streamlabel = streamlabel

--- a/pluma/stream/microphone.py
+++ b/pluma/stream/microphone.py
@@ -17,7 +17,7 @@ class MicrophoneStream (Stream):
               fs: float = None,
               channels: int = 2,
               si_conversion: SiUnitConversion = SiUnitConversion(),
-              clockreferenceid: ClockRefId = ClockRefId.HARP,
+              clockreferenceid: ClockRefId = ClockRefId.NONE,
               **kw):
 		super(MicrophoneStream, self).__init__(data=data, **kw)
 		self.streamtype = StreamType.MICROPHONE


### PR DESCRIPTION
Clock reference objects were initialized as a default mutable argument in the `Stream` base class. Since they were almost never explicitly set in the call to the base constructor, all streams shared a global state object and could therefore report an incorrect clock reference.

This has been fixed, and the `MicrophoneStream` clock reference also set to `None` to correctly indicate the absence of sample-by-sample synchronization for the raw audio data stream.