### PR TITLE
Allow empty EEG streams

### DIFF
--- a/pluma/io/eeg.py
+++ b/pluma/io/eeg.py
@@ -26,7 +26,8 @@ def get_eeg_file(root: Union[str, ComplexPath] = '',
 
     expected_files = filename.glob(filename.path)
     if len(expected_files) == 0:
-        raise FileNotFoundError(f"No *.nedf files found in {root}.")
+        warnings.warn(f"No *.nedf files found in {root}.")
+        ret = None
     elif len(expected_files) > 1:
         warnings.warn(f"Multiple *.nedf files found in {root}. "
                       f"Loading {expected_files[if_multiple_load_index]}.")
@@ -62,6 +63,8 @@ def load_eeg(filename: Optional[str] = None,
     root = ensure_complexpath(root)
     if filename is None:
         filename = get_eeg_file(root)
+        if filename is None:
+            return (None, None)
     else:
         root.join(filename)
         filename = root

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -257,7 +257,7 @@ class Dataset:
         Dataset._offset_data_index(self.georeference.spacetime, utc_offset)
         Dataset._offset_data_index(self.georeference.time, utc_offset)
         for stream in self._iter_schema_streams(self.streams):
-            if len(stream.data) == 0:
+            if stream.data is None:
                 continue
             if stream.clockreference.referenceid == ClockRefId.HARP:
                 Dataset._offset_data_index(stream.data, utc_offset)

--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -31,8 +31,6 @@ class EegStream(Stream):
 		self.server_lsl_marker = server_lsl_marker
 		if self.autoload:
 			self.load()
-			if (self.autoalign and (self.clockreference.referenceid == ClockRefId.HARP)):
-				self.align_to_harp()
 
 	def load(self):
 		self.data, _lsl_timestamp = load_eeg(
@@ -40,8 +38,8 @@ class EegStream(Stream):
 			root=self.rootfolder)
 		if self.server_lsl_marker is None:
 			self.server_lsl_marker = _lsl_timestamp
-			if (self.autoalign and (self.clockreference.referenceid == ClockRefId.HARP)):
-				self.align_to_harp()
+		if self.data is not None and self.autoalign and (self.clockreference.referenceid == ClockRefId.HARP):
+			self.align_to_harp()
 
 	def align_to_harp(self):
 		print("Attempting to automatically correct eeg timestamps to harp timestamps...")


### PR DESCRIPTION
To allow a single schema to describe different collection conditions, and allow for quicker inspection of data quality, this PR introduces a nullable representation for EEG streams. If no NEDF files are found, a warning is issued, but the rest of the dataset will be imported successfully.