### PR TITLE
Allow arbitrary clock referencing strategies

### DIFF
--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -139,3 +139,9 @@ def _get_georef(stream: Stream) -> pd.DataFrame:
                 Calibrate the Dataset before exporting the stream by\
                     calling Dataset.add_georeference_and_calibrate()")
     return stream.parent_dataset.georeference
+
+
+def rereference_stream_index_origin(data, origin):
+    """Rebases the origin of the specified stream data index."""
+    if len(data) > 0:
+        data.index += origin - data.index[0]

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -65,6 +65,9 @@ class Stream:
 
 	def resample(self):
 		raise NotImplementedError("resample() method is not implemented for the Stream base class.")
+	
+	def rereference_clock_origin(self, offset):
+		raise NotImplementedError("offset_time() method is not implemented for the Stream base class.")
 
 	def reload(self):
 		self.load()

--- a/pluma/stream/accelerometer.py
+++ b/pluma/stream/accelerometer.py
@@ -5,7 +5,7 @@ from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.io.accelerometer import load_accelerometer, _accelerometer_header
 from pluma.sync import ClockRefId
-from pluma.export.streams import resample_stream_accelerometer
+from pluma.export.streams import rereference_stream_index_origin, resample_stream_accelerometer
 
 class AccelerometerStream(Stream):
 	"""_summary_
@@ -54,3 +54,6 @@ class AccelerometerStream(Stream):
 	      sampling_dt: datetime.timedelta,
 		  **kwargs) -> pd.DataFrame:
 		return resample_stream_accelerometer(self, sampling_dt, **kwargs)
+	
+	def rereference_clock_origin(self, origin):
+		rereference_stream_index_origin(self.data, origin)

--- a/pluma/stream/csv.py
+++ b/pluma/stream/csv.py
@@ -6,6 +6,7 @@ from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.sync import ClockRefId
 from pluma.io.path_helper import ensure_complexpath
+from pluma.export.streams import rereference_stream_index_origin
 
 
 class CsvStream(Stream):
@@ -44,3 +45,6 @@ class CsvStream(Stream):
 
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
+
+    def rereference_clock_origin(self, origin):
+        rereference_stream_index_origin(self.data, origin)

--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -49,5 +49,8 @@ class EegStream(Stream):
 			.flatten())
 		print("Done.")
 
+	def rereference_clock_origin(self, origin):
+		self.data.np_time += origin - self.data.np_time[0]
+
 	def __str__(self):
 		return f'EEG stream from device {self.device}, stream {self.streamlabel}'

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -4,7 +4,7 @@ import datetime
 from pluma.stream import Stream, StreamType
 from pluma.io.empatica import load_empatica
 from pluma.sync import ClockRefId
-from pluma.export.streams import resample_stream_empatica
+from pluma.export.streams import rereference_stream_index_origin, resample_stream_empatica
 
 
 class EmpaticaStream(Stream):
@@ -33,3 +33,7 @@ class EmpaticaStream(Stream):
 	      sampling_dt: datetime.timedelta,
 	      **kwargs) -> pd.DataFrame:
 		return resample_stream_empatica(self, sampling_dt, **kwargs)
+	
+	def rereference_clock_origin(self, origin):
+		for stream in self.data.values():
+			rereference_stream_index_origin(stream, origin)

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -9,7 +9,7 @@ from pluma.stream.siconversion import SiUnitConversion
 
 from pluma.sync import ClockRefId
 
-from pluma.export.streams import export_stream_to_csv, resample_stream_harp
+from pluma.export.streams import export_stream_to_csv, resample_stream_harp, rereference_stream_index_origin
 
 
 class HarpStream(Stream):
@@ -72,3 +72,6 @@ class HarpStream(Stream):
 	      sampling_dt: datetime.timedelta,
 		  **kwargs) -> pd.DataFrame:
 		return resample_stream_harp(self, sampling_dt, **kwargs)
+	
+	def rereference_clock_origin(self, origin):
+		rereference_stream_index_origin(self.data, origin)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pluma.stream import StreamType
 from pluma.stream import Stream
 from pluma.io.zeromq import load_zeromq
+from pluma.export.streams import rereference_stream_index_origin
 
 
 class PupilStream(Stream):
@@ -23,10 +24,13 @@ class PupilStream(Stream):
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
 
+    def rereference_clock_origin(self, origin):
+        rereference_stream_index_origin(self.data, origin)
+
 
 class GliaStream(Stream):
     def __init__(self, **kw):
-        super(PupilStream, self).__init__(**kw)
+        super(GliaStream, self).__init__(**kw)
 
         self.streamtype = StreamType.GLIA
         if self.autoload:
@@ -40,6 +44,9 @@ class GliaStream(Stream):
 
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
+
+    def rereference_clock_origin(self, origin):
+        rereference_stream_index_origin(self.data, origin)
 
 
 class UnityStream(Stream):
@@ -58,6 +65,9 @@ class UnityStream(Stream):
 
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
+
+    def rereference_clock_origin(self, origin):
+        rereference_stream_index_origin(self.data, origin)
 
 
 class PupilGazeStream(PupilStream):


### PR DESCRIPTION
To allow arbitrary referencing of the Harp data clock may require custom implementations to traverse the diverse object types which may represent a stream `data` attribute.

To allow for greater flexibility of implementations, e.g. in the case of EEG where we don't even control the reader class itself, this PR refactors the `reference_harp_to_ubx_time` method to use polymorphism, by introducing a new `rereference_clock_origin` in the base `Stream` class. This allows implementations to specify how exactly to apply a new arbitrary clock offset to the stream data.