### PR TITLE
Ensure consistent clock reference

### DIFF
--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -141,7 +141,7 @@ def _get_georef(stream: Stream) -> pd.DataFrame:
     return stream.parent_dataset.georeference
 
 
-def rereference_stream_index_origin(data, origin):
-    """Rebases the origin of the specified stream data index."""
+def shift_stream_index(data, offset):
+    """Offsets the specified stream data index."""
     if len(data) > 0:
-        data.index += origin - data.index[0]
+        data.index += offset

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -6,7 +6,7 @@ import datetime
 from dotmap import DotMap
 from typing import Union, Optional, Callable
 
-from pluma.export.streams import rereference_stream_index_origin
+from pluma.export.streams import shift_stream_index
 from pluma.schema.outdoor import build_schema
 
 from pluma.sync.ubx2harp import SyncLookup, get_clockcalibration_model, get_clockcalibration_lookup
@@ -246,14 +246,14 @@ class Dataset:
         if self.has_calibration is False:
             raise AssertionError('Dataset is not calibrated to UBX time.')
 
-        utc_offset = self.streams.UBX.positiondata['Time_UTC'][0]
-        rereference_stream_index_origin(self.georeference.spacetime, utc_offset)
-        rereference_stream_index_origin(self.georeference.time, utc_offset)
+        utc_offset = self.streams.UBX.positiondata['Time_UTC'][0] - self.georeference.time[0]
+        shift_stream_index(self.georeference.spacetime, utc_offset)
+        shift_stream_index(self.georeference.time, utc_offset)
         for stream in self._iter_schema_streams(self.streams):
             if stream.data is None:
                 continue
             if stream.clockreference.referenceid == ClockRefId.HARP:
-                stream.rereference_clock_origin(utc_offset)
+                stream.add_clock_offset(utc_offset)
                 stream.clockreference.referenceid = ClockRefId.GNSS
         
     def to_geoframe(self,

--- a/pluma/stream/__init__.py
+++ b/pluma/stream/__init__.py
@@ -66,8 +66,8 @@ class Stream:
 	def resample(self):
 		raise NotImplementedError("resample() method is not implemented for the Stream base class.")
 	
-	def rereference_clock_origin(self, offset):
-		raise NotImplementedError("offset_time() method is not implemented for the Stream base class.")
+	def add_clock_offset(self, offset):
+		raise NotImplementedError("add_clock_offset() method is not implemented for the Stream base class.")
 
 	def reload(self):
 		self.load()

--- a/pluma/stream/accelerometer.py
+++ b/pluma/stream/accelerometer.py
@@ -5,7 +5,7 @@ from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.io.accelerometer import load_accelerometer, _accelerometer_header
 from pluma.sync import ClockRefId
-from pluma.export.streams import rereference_stream_index_origin, resample_stream_accelerometer
+from pluma.export.streams import shift_stream_index, resample_stream_accelerometer
 
 class AccelerometerStream(Stream):
 	"""_summary_
@@ -55,5 +55,5 @@ class AccelerometerStream(Stream):
 		  **kwargs) -> pd.DataFrame:
 		return resample_stream_accelerometer(self, sampling_dt, **kwargs)
 	
-	def rereference_clock_origin(self, origin):
-		rereference_stream_index_origin(self.data, origin)
+	def add_clock_offset(self, offset):
+		shift_stream_index(self.data, offset)

--- a/pluma/stream/csv.py
+++ b/pluma/stream/csv.py
@@ -6,7 +6,7 @@ from pluma.stream import Stream, StreamType
 from pluma.stream.siconversion import SiUnitConversion
 from pluma.sync import ClockRefId
 from pluma.io.path_helper import ensure_complexpath
-from pluma.export.streams import rereference_stream_index_origin
+from pluma.export.streams import shift_stream_index
 
 
 class CsvStream(Stream):
@@ -46,5 +46,5 @@ class CsvStream(Stream):
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
 
-    def rereference_clock_origin(self, origin):
-        rereference_stream_index_origin(self.data, origin)
+    def add_clock_offset(self, offset):
+        shift_stream_index(self.data, offset)

--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -49,8 +49,10 @@ class EegStream(Stream):
 			.flatten())
 		print("Done.")
 
-	def rereference_clock_origin(self, origin):
-		self.data.np_time += origin - self.data.np_time[0]
+	def add_clock_offset(self, offset):
+		if self.server_lsl_marker is not None:
+			self.server_lsl_marker['Seconds'] += offset
+		self.data.np_time += offset
 
 	def __str__(self):
 		return f'EEG stream from device {self.device}, stream {self.streamlabel}'

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -4,7 +4,7 @@ import datetime
 from pluma.stream import Stream, StreamType
 from pluma.io.empatica import load_empatica
 from pluma.sync import ClockRefId
-from pluma.export.streams import rereference_stream_index_origin, resample_stream_empatica
+from pluma.export.streams import shift_stream_index, resample_stream_empatica
 
 
 class EmpaticaStream(Stream):
@@ -34,6 +34,6 @@ class EmpaticaStream(Stream):
 	      **kwargs) -> pd.DataFrame:
 		return resample_stream_empatica(self, sampling_dt, **kwargs)
 	
-	def rereference_clock_origin(self, origin):
+	def add_clock_offset(self, offset):
 		for stream in self.data.values():
-			rereference_stream_index_origin(stream, origin)
+			shift_stream_index(stream, offset)

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -9,7 +9,7 @@ from pluma.stream.siconversion import SiUnitConversion
 
 from pluma.sync import ClockRefId
 
-from pluma.export.streams import export_stream_to_csv, resample_stream_harp, rereference_stream_index_origin
+from pluma.export.streams import export_stream_to_csv, resample_stream_harp, shift_stream_index
 
 
 class HarpStream(Stream):
@@ -73,5 +73,5 @@ class HarpStream(Stream):
 		  **kwargs) -> pd.DataFrame:
 		return resample_stream_harp(self, sampling_dt, **kwargs)
 	
-	def rereference_clock_origin(self, origin):
-		rereference_stream_index_origin(self.data, origin)
+	def add_clock_offset(self, offset):
+		shift_stream_index(self.data, offset)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pluma.stream import StreamType
 from pluma.stream import Stream
 from pluma.io.zeromq import load_zeromq
-from pluma.export.streams import rereference_stream_index_origin
+from pluma.export.streams import shift_stream_index
 
 
 class PupilStream(Stream):
@@ -24,8 +24,8 @@ class PupilStream(Stream):
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
 
-    def rereference_clock_origin(self, origin):
-        rereference_stream_index_origin(self.data, origin)
+    def add_clock_offset(self, offset):
+        shift_stream_index(self.data, offset)
 
 
 class GliaStream(Stream):
@@ -45,8 +45,8 @@ class GliaStream(Stream):
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
 
-    def rereference_clock_origin(self, origin):
-        rereference_stream_index_origin(self.data, origin)
+    def add_clock_offset(self, offset):
+        shift_stream_index(self.data, offset)
 
 
 class UnityStream(Stream):
@@ -66,8 +66,8 @@ class UnityStream(Stream):
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
 
-    def rereference_clock_origin(self, origin):
-        rereference_stream_index_origin(self.data, origin)
+    def add_clock_offset(self, offset):
+        shift_stream_index(self.data, offset)
 
 
 class PupilGazeStream(PupilStream):


### PR DESCRIPTION
The refactoring in #42 and #44 introduced a critical regression since referencing time must always be done around an identical anchor point, rather than around the first time point of each series.

This PR references time around the first UBX time point, and applies a consistent offset to every data stream clock.