### PR TITLE
Resample geospatial data using geopandas

### DIFF
--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -9,7 +9,7 @@ from dotmap import DotMap
 from pluma.stream import Stream
 
 
-exclude_devices = ["PupilLabs", "Microphone", "Empatica", "BioData", "UBX"]
+exclude_devices = ["PupilLabs", "Microphone", "Empatica", "BioData", "Enobio", "UBX"]
 
 
 def convert_dataset_to_geoframe(

--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -3,8 +3,9 @@ import os
 import datetime
 import pandas as pd
 import geopandas as gpd
-from dotmap import DotMap
+import pluma.preprocessing.resampling as resampling
 
+from dotmap import DotMap
 from pluma.stream import Stream
 
 
@@ -16,16 +17,13 @@ def convert_dataset_to_geoframe(
         sampling_dt: datetime.timedelta = datetime.timedelta(seconds=1)
         ):
 
+    georef = resampling.resample_georeference(dataset.georeference.spacetime, sampling_dt)
     streams_to_export = {}
     for stream in dataset.streams:
         _ = recursive_resample_stream(
-            streams_to_export, dataset.streams[stream], sampling_dt)
+            streams_to_export, dataset.streams[stream], georef)
 
     exclude = ['Latitude', 'Longitude', 'Elevation']
-
-    out = streams_to_export[list(streams_to_export.keys())[0]].copy()
-    out = out.iloc[:, 0:3]
-
     out_columns = []
     for stream in streams_to_export:
         cols = list(streams_to_export[stream].columns)
@@ -36,16 +34,13 @@ def convert_dataset_to_geoframe(
             cols[idx] = (stream if entry.lower() == "data" else
                          f"{stream}_{entry}").lower()
         streams_to_export[stream].columns = cols
-        out_columns.append(streams_to_export[stream].drop(exclude, axis=1))
-    out = out.join(out_columns)
-    out.index.name = 'time'
+        out_columns.append(streams_to_export[stream])
 
-    geometry = gpd.points_from_xy(
-        x=out['Longitude'],
-        y=out['Latitude'],
-        z=out['Elevation'])
-    out = gpd.GeoDataFrame(out.drop(exclude, axis=1), geometry=geometry)
-    out.crs = 'epsg:4326'
+    geometry = out_columns[0][out_columns[0].columns[-1]]
+    out = gpd.GeoDataFrame(pd.concat([d.drop(d.columns[-1], axis=1)
+                                      for d in out_columns], axis=1),
+                                      geometry=geometry)
+    out.index.name = 'time'
     return out
 
 def export_dataset_to_geojson(

--- a/pluma/preprocessing/resampling.py
+++ b/pluma/preprocessing/resampling.py
@@ -37,8 +37,11 @@ def resample_temporospatial(data: pd.DataFrame,
         resampled = georeference
     else:
         resampled = resample_georeference(georeference, sampling_dt)
-    resampled_data_index = resampled.index[resampled.index.searchsorted(data.index)]
-    resampled_data = data.groupby(resampled_data_index)
+
+    resampled_indices = resampled.index.searchsorted(data.index) - 1
+    valid_data_values = resampled_indices >= 0
+    resampled_data_index = resampled.index[resampled_indices[valid_data_values]]
+    resampled_data = data[valid_data_values].groupby(resampled_data_index)
 
     if (aggregate_func is None):
         resampled_data = resampled_data.mean()

--- a/pluma/preprocessing/resampling.py
+++ b/pluma/preprocessing/resampling.py
@@ -1,20 +1,21 @@
 import datetime
 import numpy as np
 import pandas as pd
+import geopandas as gpd
 
 from scipy.stats import circmean
 
 
-def resample_temporospatial(input_data: pd.DataFrame,
+def resample_temporospatial(data: pd.DataFrame,
                             georeference: pd.DataFrame,
-                            sampling_dt:
-                                datetime.timedelta
-                                = datetime.timedelta(seconds=2))\
-                                    -> pd.DataFrame:
+                            sampling_dt: datetime.timedelta
+                                = datetime.timedelta(seconds=2),
+                            aggregate_func=None)\
+                                    -> gpd.GeoDataFrame:
     """Temporally resamples a temporally indexed data stream and aligns it to a spatial reference.
 
     Args:
-        input_data (pd.DataFrame): DataFrame with data index by time
+        data (pd.DataFrame): DataFrame with data index by time
         georeference (pd.DataFrame): a geoference, usually the output of Streams.ubxStream.UbxStream.parseposition, or equivalent.
         sampling_dt (datetime.timedelta, optional): _description_. Defaults to datetime.timedelta(seconds = 2).
 
@@ -22,38 +23,40 @@ def resample_temporospatial(input_data: pd.DataFrame,
         ValueError: Raises an error if the input DataFrame is empty.
 
     Returns:
-        pd.DataFrame: Returns a resampled DataFrame.
+        gpd.GeoDataFrame: Returns a resampled GeoDataFrame.
     """
-    if input_data.empty:
+    if data.empty:
         raise ValueError("Input dataframe is empty.")
 
     resampled = georeference.spacetime.loc\
         [:, "Latitude":"Elevation"].resample(
             sampling_dt, origin='start').mean()
-    resampled['Data'] = np.NAN
-    for i in np.arange(len(resampled)-1):
-        resampled['Data'].iloc[i] = (input_data[
-            (input_data.index >= resampled.index[i]) &
-            (input_data.index < resampled.index[i+1])]).mean()
-    resampled['Data'].iloc[i+1] = (
-        input_data[input_data.index >= resampled.index[i+1]]).mean()
-    return resampled
+    resampled_data_index = resampled.index[resampled.index.searchsorted(data.index)]
+    resampled_data = data.groupby(resampled_data_index)
+
+    if (aggregate_func is None):
+        resampled_data = resampled_data.mean()
+    else:
+        resampled_data = resampled_data.apply(aggregate_func)
+        
+    resampled_data = resampled_data.reindex(resampled.index)
+    return _create_geodataframe(resampled_data, resampled)
 
 
-def resample_temporospatial_circ(input_data,
+def resample_temporospatial_circ(data,
                                  georeference,
                                  sampling_dt=datetime.timedelta(seconds=2)):
-    resampled = georeference.spacetime.loc[:, "Latitude":"Elevation"].\
-        resample(sampling_dt, origin='start').mean()
-    resampled['Data'] = np.NAN
-    for i in np.arange(len(resampled)-1):
-        resampled['Data'].iloc[i] = circular_mean((input_data[
-            (input_data.index >= resampled.index[i]) &
-            (input_data.index < resampled.index[i+1])]))
-    resampled['Data'].iloc[i+1] = circular_mean(
-        input_data[input_data.index >= resampled.index[i+1]]
-        )
-    return resampled
+    return resample_temporospatial(data, georeference, sampling_dt, circular_mean)
+
+
+def _create_geodataframe(data, spacetime):
+    geometry = gpd.points_from_xy(
+        x=spacetime['Longitude'],
+        y=spacetime['Latitude'],
+        z=spacetime['Elevation'])
+    gdf = gpd.GeoDataFrame(data, geometry=geometry)
+    gdf.crs = 'epsg:4326'
+    return gdf
 
 
 def circular_mean(x):

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -29,10 +29,8 @@ class EmpaticaStream(Stream):
 	def __str__(self):
 		return f'Empatica stream from device {self.device}, stream {self.streamlabel}'
 
-	def resample(self,
-	      sampling_dt: datetime.timedelta,
-	      **kwargs) -> pd.DataFrame:
-		return resample_stream_empatica(self, sampling_dt, **kwargs)
+	def resample(self, sampling_dt: datetime.timedelta) -> pd.DataFrame:
+		return resample_stream_empatica(self, sampling_dt)
 	
 	def add_clock_offset(self, offset):
 		for stream in self.data.values():

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -68,10 +68,8 @@ class HarpStream(Stream):
 	def export_to_csv(self, root_path, **kwargs):
 		export_stream_to_csv(self, root_path, **kwargs)
 
-	def resample(self,
-	      sampling_dt: datetime.timedelta,
-		  **kwargs) -> pd.DataFrame:
-		return resample_stream_harp(self, sampling_dt, **kwargs)
+	def resample(self, sampling_dt: datetime.timedelta) -> pd.DataFrame:
+		return resample_stream_harp(self, sampling_dt)
 	
 	def add_clock_offset(self, offset):
 		shift_stream_index(self.data, offset)


### PR DESCRIPTION
In order to facilitate data export and more powerful tooling for geospatial data manipulation, visualization and exploration, this PR refactors the entire geospatial preprocessing pipeline to use `geopandas.GeoDataFrame`. This allows replacing the use of `showmaps` with the interactive [`explore`](https://geopandas.org/en/stable/docs/user_guide/interactive_mapping.html) method of `geopandas`.

It also allows for more optimized dataframe merging and caching routines using directly `geopandas` functionality. The resampling strategy for data was checked for consistency with temporal resampling of geospatial points, i.e. each resampled row represents the average of data in the same time bin of the corresponding GNSS position.