### PR TITLE
Add support for interactive maps

### DIFF
--- a/pluma/export/maps.py
+++ b/pluma/export/maps.py
@@ -77,6 +77,17 @@ def showmap(path,
     return fig
 
 
+def exploremap(data: gpd.GeoDataFrame, **kwargs):
+    index = data.index
+    data = data.reset_index(drop=True)
+    if not 'column' in kwargs:
+        minutes = (index - index[0]).to_series(index=data.index).dt.total_seconds() / 60
+        kwargs['column'] = minutes
+    if not 'cmap' in kwargs:
+        kwargs['cmap'] = 'jet'
+    return data.explore(**kwargs)
+
+
 def export_kml_line(df: pd.DataFrame,
                     output_path: str = "walk.kml",
                     **kwargs):

--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -229,9 +229,7 @@ class Dataset:
     def showmap(self, **kwargs):
         """Overload to export.showmap that shows spatial information color-coded by time.
         """
-        temp_df = self.georeference.spacetime.assign(Data=1)
-        fig = maps.showmap(temp_df, **kwargs)
-        return fig
+        return maps.showmap(self.georeference.spacetime, **kwargs)
 
     def add_georeference_and_calibrate(self, plot_diagnosis=True):
         if self.has_calibration is False:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ license = {text = "MIT License"}
 dependencies = [
     "geopandas",
     "matplotlib",
+    "mapclassify",
+    "folium",
     "numpy",
     "scipy",
     "scikit-learn",


### PR DESCRIPTION
Adds a new `exploremap` function wrapping the [`explore`](https://geopandas.org/en/stable/docs/user_guide/interactive_mapping.html) method with useful defaults for plotting the temporal progression of the path since timestamp indices are not supported out-of-the-box by `geopandas`.