### PR TITLE
Add support for aligning E4 hardware timestamps

### DIFF
--- a/pluma/io/empatica.py
+++ b/pluma/io/empatica.py
@@ -11,12 +11,14 @@ from pluma.io.path_helper import ComplexPath, ensure_complexpath
 _EMPATICA_T0 = datetime.datetime(1970, 1, 1)
 
 def load_empatica(filename: str = 'empatica_harp_ts.csv',
-                  root: Union[str, ComplexPath] = '') -> DotMap:
+                  root: Union[str, ComplexPath] = '',
+                  align_timestamps: bool = True) -> DotMap:
     """Loads the raw Empatica data stream, from a .csv file, to a DotMap structure.
 
     Args:
         filename (str, optional): Input file name to target. Defaults to 'empatica_harp_ts.csv'.
         root (Union[str, ComplexPath], optional): Root path where filename is expected to be found. Defaults to ''.
+        align_timestamps (bool, optional): Specifies whether to align time to E4 sensor timestamps.
 
     Returns:
         DotMap: DotMap where each Empatica message type can be indexed.
@@ -36,20 +38,29 @@ def load_empatica(filename: str = 'empatica_harp_ts.csv',
         warnings.warn(f'Empatica stream file {filename} could not be found.')
         return
 
+    clock_offset = None
     df['Seconds'] = _HARP_T0 + pd.to_timedelta(df['Seconds'].values, 's')
+    if align_timestamps:
+        first_ts = next((x for _, x in df.iterrows() if x['Message'].startswith('E4_')), None)
+        if first_ts is not None:
+            reference_ts = _EMPATICA_T0 + pd.to_timedelta(float(first_ts['Message'].split(' ')[1]), 's')
+            clock_offset = first_ts['Seconds'] - reference_ts
+
     df.set_index('Seconds', inplace=True)
     df['StreamId'] = df['Message'].apply(lambda x: x.split(' ')[0])
     _dict = {}
     for label, group in df.groupby('StreamId'):
-        _dict[label] = parse_empatica_stream(group)
+        _dict[label] = parse_empatica_stream(group, clock_offset)
     return DotMap(_dict)
 
 
-def parse_empatica_stream(empatica_stream: pd.DataFrame) -> pd.DataFrame:
+def parse_empatica_stream(empatica_stream: pd.DataFrame,
+                          clock_offset: pd.Timedelta = None) -> pd.DataFrame:
     """Helper function to parse the messages from various empatica message types.
 
     Args:
         empatica_stream (pd.DataFrame): CSV data in DataFrame format
+        clock_offset (pd.Timedelta, optional): Optional clock offset used to index time from E4 timestamps.
 
     Returns:
         pd.DataFrame: A DataFrame with parsed relevant empatica data indexed by time.
@@ -63,6 +74,8 @@ def parse_empatica_stream(empatica_stream: pd.DataFrame) -> pd.DataFrame:
             df[['AccX', 'AccY', 'AccZ']].astype(float)
         df['E4_Seconds'] = _EMPATICA_T0 + \
             pd.to_timedelta(df['E4_Seconds'].values.astype(float), 's')
+        if clock_offset is not None:
+            df.index = pd.DatetimeIndex(df['E4_Seconds'] + clock_offset, name=df.index.name)
 
     elif stream_id in \
         ['E4_Hr', 'E4_Bvp',
@@ -76,6 +89,8 @@ def parse_empatica_stream(empatica_stream: pd.DataFrame) -> pd.DataFrame:
         df[['Value']] = df[['Value']].astype(float)
         df['E4_Seconds'] = _EMPATICA_T0 +\
             pd.to_timedelta(df['E4_Seconds'].values.astype(float), 's')
+        if clock_offset is not None:
+            df.index = pd.DatetimeIndex(df['E4_Seconds'] + clock_offset, name=df.index.name)
     elif stream_id == 'R':
         df = pd.DataFrame(index=empatica_stream.index.copy())
         df['Message'] = empatica_stream['Message'].apply(

--- a/pluma/stream/empatica.py
+++ b/pluma/stream/empatica.py
@@ -15,16 +15,20 @@ class EmpaticaStream(Stream):
 	"""
 	def __init__(self,
               clockreferenceid: ClockRefId = ClockRefId.HARP,
+			  align_timestamps: bool = True,
               **kw):
 		super(EmpaticaStream, self).__init__(**kw)
 		self.streamtype = StreamType.EMPATICA
 		self.clockreference.referenceid = clockreferenceid
+		self.align_timestamps = align_timestamps
 
 		if self.autoload:
 			self.load()
 
 	def load(self):
-		self.data = load_empatica(root=self.rootfolder)
+		self.data = load_empatica(
+			root=self.rootfolder,
+			align_timestamps=self.align_timestamps)
 
 	def __str__(self):
 		return f'Empatica stream from device {self.device}, stream {self.streamlabel}'


### PR DESCRIPTION
Continuous alignment of E4 timestamps with Harp has been complicated by burst transmission of messages through the Bluetooth serial link.

However, the E4 deltas themselves have low enough drift on the sampling frequencies of interest for recording durations up to one hour, so this PR provides an optional alignment based on the first message received.