### PR TITLE
Add E4 multi-stream resampling to exported geojson

### DIFF
--- a/pluma/export/ogcapi/features.py
+++ b/pluma/export/ogcapi/features.py
@@ -9,7 +9,7 @@ from dotmap import DotMap
 from pluma.stream import Stream
 
 
-exclude_devices = ["PupilLabs", "Microphone", "Empatica", "BioData", "Enobio", "UBX"]
+exclude_devices = ["PupilLabs", "Microphone", "BioData", "Enobio", "UBX"]
 
 
 def convert_dataset_to_geoframe(

--- a/pluma/preprocessing/resampling.py
+++ b/pluma/preprocessing/resampling.py
@@ -49,7 +49,7 @@ def resample_temporospatial(data: pd.DataFrame,
         resampled_data = resampled_data.apply(aggregate_func)
         
     resampled_data = resampled_data.reindex(resampled.index)
-    return _create_geodataframe(resampled_data, resampled)
+    return gpd.GeoDataFrame(resampled_data, geometry=resampled.geometry)
 
 
 def resample_temporospatial_circ(data,
@@ -59,17 +59,14 @@ def resample_temporospatial_circ(data,
 
 
 def resample_georeference(georeference: pd.DataFrame,
-                          sampling_dt: datetime.timedelta):
-    return georeference.loc[:, "Latitude":"Elevation"].resample(
+                          sampling_dt: datetime.timedelta) -> gpd.GeoDataFrame:
+    georeference = georeference.loc[:, "Latitude":"Elevation"].resample(
         sampling_dt, origin='start').mean()
-
-
-def _create_geodataframe(data, spacetime):
     geometry = gpd.points_from_xy(
-        x=spacetime['Longitude'],
-        y=spacetime['Latitude'],
-        z=spacetime['Elevation'])
-    gdf = gpd.GeoDataFrame(data, geometry=geometry)
+        x=georeference['Longitude'],
+        y=georeference['Latitude'],
+        z=georeference['Elevation'])
+    gdf = gpd.GeoDataFrame(georeference, geometry=geometry)
     gdf.crs = 'epsg:4326'
     return gdf
 


### PR DESCRIPTION
There was a regression in E4 data stream resampling due to multi-dimensional data frames. This PR generalizes multi-stream resampling to allow for multi-dimensional data frames, ensures naming of frames is correct, and includes E4 resampling in exported GeoJSON records, if available.