### PR TITLE
Add specialized ECG stream with heartrate data

### DIFF
--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -112,8 +112,12 @@ def resample_stream_empatica(stream: Stream,
 def resample_stream_ecg(stream: Stream,
                         sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2)
                         ) -> gpd.GeoDataFrame:
-    col_sampler = { 'Bpm': resampling.resample_temporospatial }
-    return _resample_multistream(stream, col_sampler, sampling_dt)
+    col_sampler = { 'HeartRate': resampling.resample_temporospatial }
+    return _resample_multistream(
+        stream,
+        col_sampler,
+        sampling_dt,
+        data_selector = lambda x: x['Bpm'])
 
 
 def _resample_multistream(

--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -109,6 +109,13 @@ def resample_stream_empatica(stream: Stream,
         data_selector = lambda x: x['Value'])
 
 
+def resample_stream_ecg(stream: Stream,
+                        sampling_dt: datetime.timedelta = datetime.timedelta(seconds=2)
+                        ) -> gpd.GeoDataFrame:
+    col_sampler = { 'Bpm': resampling.resample_temporospatial }
+    return _resample_multistream(stream, col_sampler, sampling_dt)
+
+
 def _resample_multistream(
         stream: Stream,
         col_sampler: dict[str, Callable],

--- a/pluma/preprocessing/ecg.py
+++ b/pluma/preprocessing/ecg.py
@@ -1,18 +1,20 @@
 import numpy as np
 import pandas as pd
+from typing import Union
 
 from scipy import signal
 
 from pluma.preprocessing import utils
+from pluma.stream import Stream
 
-def heartrate_from_ecg(ecg_data_stream,
+def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
                        fs : float = 250, skip_slice : int = 4, max_heartrate_bpm : float = 200.0,
                        peak_height : float = 800, smooth_win : int = 10, invert : bool = False) -> tuple:
     ## Load biodata
     """Calculates heart rate from the raw ECG waveform signal
 
     Args:
-        ecg_data_stream (_type_): ECG input data
+        ecg_data (Stream or DataFrame): ECG input data
         fs (float, optional): ECG sampling rate (Hz). Defaults to 250.
         skip_slice (int, optional): How to slice the incoming raw array. Fs corresponds to the sampling rate post-slicing. Defaults to 4.
         max_heartrate_bpm (float, optional): Maximum theoretical heartrate. Defaults to 200.0.
@@ -23,19 +25,22 @@ def heartrate_from_ecg(ecg_data_stream,
     Returns:
         tuple: Tuple with a DataFrame containing timestamped heartbeats, and an array with the processed waveform signal, respectively.
     """
-    ecg = ecg_data_stream.data
+
+    if isinstance(ecg, Stream):
+        ecg = ecg.data
+
     if invert:
         ecg = ecg * (-1.0)
     ecg = ecg["Value0"].iloc[np.arange(len(ecg))[::skip_slice]].astype(np.float64) # sensor acquires at 250hz but saves at 1khz
 
-    resampled = utils.butter_highpass_filter(ecg,5,fs)
+    filtered = utils.butter_highpass_filter(ecg,5,fs)
 
     #Assume maximum heartrate of max_heartrate_bpm
-    peaks, _  = signal.find_peaks(resampled, height = peak_height, distance = (1.0/(max_heartrate_bpm/60.0)) * fs )
+    peaks, _  = signal.find_peaks(filtered, height = peak_height, distance = (1.0/(max_heartrate_bpm/60.0)) * fs )
     heartrate = (fs/np.diff(peaks)) * 60
     heartrate = np.convolve(heartrate, np.ones(smooth_win), 'same') / smooth_win
     heartrate[0:int(smooth_win/2)+1] = np.NaN # pad the invalid portion of the conv with NaN
     heartrate[-int(smooth_win/2)-1:-1] = np.NaN
     df = pd.DataFrame(index = ecg.index[peaks[1:]], copy = True)
-    df['HeartRate'] = heartrate
-    return (df, resampled)
+    df['Bpm'] = heartrate
+    return (df, filtered, peaks)

--- a/pluma/preprocessing/ecg.py
+++ b/pluma/preprocessing/ecg.py
@@ -45,6 +45,7 @@ def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
     
     if bpm_method == 'heartpy':
         heartrate = 60000 / np.array(working_data['RR_list_cor'])
+        heartrate = np.clip(heartrate, None, bpmmax)
         peak_index = np.array(working_data['RR_indices'])[:, 1] # align to end peak
         peak_mask = np.array(working_data['RR_masklist']) == 0
         peak_index = ecg.index[peak_index][peak_mask]
@@ -53,6 +54,7 @@ def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
         peak_index = ecg.index[peaklist]
         ibi = peak_index.to_series().diff().dt.total_seconds()
         heartrate = 60 / ibi.rolling(window=pd.to_timedelta(60, 's')).mean()
+        heartrate = heartrate.clip(None, bpmmax)
     else:
         raise ValueError("The specified heartrate calculation method is not supported.")
 

--- a/pluma/preprocessing/ecg.py
+++ b/pluma/preprocessing/ecg.py
@@ -56,6 +56,7 @@ def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
     else:
         raise ValueError("The specified heartrate calculation method is not supported.")
 
+    filtered = pd.DataFrame(filtered, index=ecg.index, columns=['Ecg'])
     bpm = pd.DataFrame(index = peak_index, copy = True)
     bpm['Bpm'] = heartrate
     return (bpm, filtered, working_data, measures)

--- a/pluma/preprocessing/ecg.py
+++ b/pluma/preprocessing/ecg.py
@@ -41,7 +41,7 @@ def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
     filtered = hp.filter_signal(ecg, cutoff=highpass_cutoff, sample_rate=sample_rate, filtertype='highpass')
 
     # find peaks and compute overall beat statistics
-    working_data, measures = hp.process(ecg, sample_rate=sample_rate, bpmmax=bpmmax)
+    working_data, measures = hp.process(filtered, sample_rate=sample_rate, bpmmax=bpmmax)
     
     if bpm_method == 'heartpy':
         heartrate = 60000 / np.array(working_data['RR_list_cor'])

--- a/pluma/preprocessing/ecg.py
+++ b/pluma/preprocessing/ecg.py
@@ -1,29 +1,31 @@
 import numpy as np
 import pandas as pd
+import heartpy as hp
 from typing import Union
-
-from scipy import signal
-
-from pluma.preprocessing import utils
 from pluma.stream import Stream
 
 def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
-                       fs : float = 250, skip_slice : int = 4, max_heartrate_bpm : float = 200.0,
-                       peak_height : float = 800, smooth_win : int = 10, invert : bool = False) -> tuple:
+                       sample_rate : float = 50,
+                       skip_slice : int = 20,
+                       bpmmax : float = 200.0,
+                       highpass_cutoff : float = 5,
+                       invert : bool = False,
+                       bpm_method : str = 'heartpy') -> tuple:
     ## Load biodata
     """Calculates heart rate from the raw ECG waveform signal
 
     Args:
         ecg_data (Stream or DataFrame): ECG input data
-        fs (float, optional): ECG sampling rate (Hz). Defaults to 250.
+        sample_rate (float, optional): ECG sampling rate (Hz). Defaults to 50.
         skip_slice (int, optional): How to slice the incoming raw array. Fs corresponds to the sampling rate post-slicing. Defaults to 4.
-        max_heartrate_bpm (float, optional): Maximum theoretical heartrate. Defaults to 200.0.
-        peak_height (float, optional): Height of ECG peaks. Defaults to 800.
-        smooth_win (int, optional): Smoothing window size (in samples) used to convolve the data. Defaults to 10.
+        bpmmax (float, optional): Maximum theoretical heartrate. Defaults to 200.0.
+        highpass_cutoff (float, optional): Cutoff frequency of the high-pass filter (Hz). Defaults to 5.
+        segment_width (int, optional): Segment window size (in seconds) over which to compute heartrate. Defaults to 5.
         invert (bool, optional): If True, it will invert the raw signal (i.e. Signal * -1 ). Defaults to False.
 
     Returns:
-        tuple: Tuple with a DataFrame containing timestamped heartbeats, and an array with the processed waveform signal, respectively.
+        tuple: Tuple with a DataFrame containing timestamped heartbeats, an array with
+        the processed waveform signal, and the heartpy working_data and measures, respectively.
     """
 
     if isinstance(ecg, Stream):
@@ -31,16 +33,29 @@ def heartrate_from_ecg(ecg : Union[Stream, pd.DataFrame],
 
     if invert:
         ecg = ecg * (-1.0)
-    ecg = ecg["Value0"].iloc[np.arange(len(ecg))[::skip_slice]].astype(np.float64) # sensor acquires at 250hz but saves at 1khz
 
-    filtered = utils.butter_highpass_filter(ecg,5,fs)
+    # sensor acquires at 50hz but saves at 1khz
+    ecg = ecg.Value0[::skip_slice].astype(np.float64)
 
-    #Assume maximum heartrate of max_heartrate_bpm
-    peaks, _  = signal.find_peaks(filtered, height = peak_height, distance = (1.0/(max_heartrate_bpm/60.0)) * fs )
-    heartrate = (fs/np.diff(peaks)) * 60
-    heartrate = np.convolve(heartrate, np.ones(smooth_win), 'same') / smooth_win
-    heartrate[0:int(smooth_win/2)+1] = np.NaN # pad the invalid portion of the conv with NaN
-    heartrate[-int(smooth_win/2)-1:-1] = np.NaN
-    df = pd.DataFrame(index = ecg.index[peaks[1:]], copy = True)
-    df['Bpm'] = heartrate
-    return (df, filtered, peaks)
+    # high-pass filter seems to give consistently less rejected peaks than notch
+    filtered = hp.filter_signal(ecg, cutoff=highpass_cutoff, sample_rate=sample_rate, filtertype='highpass')
+
+    # find peaks and compute overall beat statistics
+    working_data, measures = hp.process(ecg, sample_rate=sample_rate, bpmmax=bpmmax)
+    
+    if bpm_method == 'heartpy':
+        heartrate = 60000 / np.array(working_data['RR_list_cor'])
+        peak_index = np.array(working_data['RR_indices'])[:, 1] # align to end peak
+        peak_mask = np.array(working_data['RR_masklist']) == 0
+        peak_index = ecg.index[peak_index][peak_mask]
+    elif bpm_method == 'rolling':
+        peaklist = working_data['peaklist']
+        peak_index = ecg.index[peaklist]
+        ibi = peak_index.to_series().diff().dt.total_seconds()
+        heartrate = 60 / ibi.rolling(window=pd.to_timedelta(60, 's')).mean()
+    else:
+        raise ValueError("The specified heartrate calculation method is not supported.")
+
+    bpm = pd.DataFrame(index = peak_index, copy = True)
+    bpm['Bpm'] = heartrate
+    return (bpm, filtered, working_data, measures)

--- a/pluma/stream/ecg.py
+++ b/pluma/stream/ecg.py
@@ -26,11 +26,12 @@ class EcgStream(HarpStream):
 
     def load(self):
         ecg = load_harp_stream(self.eventcode, root=self.rootfolder)
-        heartrate, filtered, _, _ = heartrate_from_ecg(ecg)
+        heartrate, filtered, working_data, measures = heartrate_from_ecg(ecg)
         self.data = DotMap({
             'Raw': ecg,
             'Filtered': filtered,
-            'HeartRate': heartrate
+            'Processed': (working_data, measures),
+            'HeartRate': heartrate,
         })
         self.si_conversion.is_si = False
 
@@ -42,4 +43,5 @@ class EcgStream(HarpStream):
     
     def add_clock_offset(self, offset):
         for stream in self.data.values():
-            shift_stream_index(stream, offset)
+            if isinstance(stream, pd.DataFrame):
+                shift_stream_index(stream, offset)

--- a/pluma/stream/ecg.py
+++ b/pluma/stream/ecg.py
@@ -1,0 +1,44 @@
+import datetime
+import pandas as pd
+
+from dotmap import DotMap
+
+from pluma.export.streams import resample_stream_ecg, shift_stream_index
+from pluma.io.harp import load_harp_stream
+from pluma.preprocessing.ecg import heartrate_from_ecg
+from pluma.stream.harp import HarpStream
+from pluma.stream.siconversion import SiUnitConversion
+from pluma.sync import ClockRefId
+
+
+class EcgStream(HarpStream):
+    def __init__(
+            self,
+            eventcode: int,
+            clockreferenceid: ClockRefId = ClockRefId.HARP,
+            **kw):
+        super().__init__(
+            eventcode,
+            data=pd.DataFrame(columns=['Seconds', 'Value']),
+            si_conversion=SiUnitConversion(),
+            clockreferenceid=clockreferenceid,
+            **kw)
+
+    def load(self):
+        ecg = load_harp_stream(self.eventcode, root=self.rootfolder)
+        heartrate, _, _ = heartrate_from_ecg(ecg)
+        self.data = DotMap({
+            'Raw': ecg,
+            'HeartRate': heartrate
+        })
+        self.si_conversion.is_si = False
+
+    def __str__(self):
+        return f'ECG stream from device {self.device}, stream {self.streamlabel}'
+    
+    def resample(self, sampling_dt: datetime.timedelta) -> pd.DataFrame:
+        return resample_stream_ecg(self, sampling_dt)
+    
+    def add_clock_offset(self, offset):
+        for stream in self.data.values():
+            shift_stream_index(stream, offset)

--- a/pluma/stream/ecg.py
+++ b/pluma/stream/ecg.py
@@ -26,7 +26,7 @@ class EcgStream(HarpStream):
 
     def load(self):
         ecg = load_harp_stream(self.eventcode, root=self.rootfolder)
-        heartrate, _, _ = heartrate_from_ecg(ecg)
+        heartrate, _, _, _ = heartrate_from_ecg(ecg)
         self.data = DotMap({
             'Raw': ecg,
             'HeartRate': heartrate

--- a/pluma/stream/ecg.py
+++ b/pluma/stream/ecg.py
@@ -26,9 +26,10 @@ class EcgStream(HarpStream):
 
     def load(self):
         ecg = load_harp_stream(self.eventcode, root=self.rootfolder)
-        heartrate, _, _, _ = heartrate_from_ecg(ecg)
+        heartrate, filtered, _, _ = heartrate_from_ecg(ecg)
         self.data = DotMap({
             'Raw': ecg,
+            'Filtered': filtered,
             'HeartRate': heartrate
         })
         self.si_conversion.is_si = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tilemapbase",
     "dotmap",
     "mne",
+    "heartpy",
     "simplekml",
     "isodate",
     "jinja2"


### PR DESCRIPTION
For analysis purposes we always need to process and extract the heartrate in beats per minute from the raw ECG data. Currently this was done via a utility function that could be applied as a post-processing step to the raw data.

This PR introduces a specialized ECG stream reader that automatically computes the heartrate as part of data loading. When using the specialized stream the data will be organized in a hierarchical dotmap with the extracted metrics, similar to other compound data streams.

Fixes #58 