### PR TITLE
Add E4 skin temperature stream to exported geojson

### DIFF
--- a/pluma/export/streams.py
+++ b/pluma/export/streams.py
@@ -100,7 +100,8 @@ def resample_stream_empatica(stream: Stream,
     col_sampler = {
         'E4_Gsr': resampling.resample_temporospatial,
         'E4_Hr': resampling.resample_temporospatial,
-        'E4_Ibi': resampling.resample_temporospatial}
+        'E4_Ibi': resampling.resample_temporospatial,
+        'E4_Temperature': resampling.resample_temporospatial}
     return _resample_multistream(
         stream,
         col_sampler,


### PR DESCRIPTION
This PR adds the skin temperature stream to the resampled data included for the OGC API features collection. The data stream was already available so it was simply a matter of adding it to the resampled dictionary.