### PR TITLE
Refactor ZMQ streams to auto load harp timestamps

### DIFF
--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from pluma.stream import StreamType
 from pluma.stream.harp import HarpStream
@@ -26,7 +27,10 @@ class ZmqStream(HarpStream):
 
     def load(self):
         super(ZmqStream, self).load()
-        self.data.rename(columns={'Value': 'Counter'}, inplace=True)
+        self.data = pd.DataFrame(
+            np.arange(len(self.data)),
+            index=self.data.index,
+            columns=['Counter'])
         zmq_data = load_zeromq(self.filenames, self.dtypes, root=self.rootfolder)
         self.data = self.data.join(zmq_data, on='Counter')
 

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -190,6 +190,7 @@ class UnityPointToOriginMapStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityPointToOriginMapStream, self).__init__(
             eventcode,
+            streamtype=StreamType.UNITY,
             filenames=[
                 'Unity_PointToOriginMap/PointToOriginMap_Frame1.bin',
                 'Unity_PointToOriginMap/PointToOriginMap_Frame2.bin'],

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -1,25 +1,34 @@
 import numpy as np
-import pandas as pd
 
 from pluma.stream import StreamType
-from pluma.stream import Stream
+from pluma.stream.harp import HarpStream
 from pluma.io.zeromq import load_zeromq
 from pluma.export.streams import shift_stream_index
 
 
-class PupilStream(Stream):
-    def __init__(self, **kw):
-        super(PupilStream, self).__init__(**kw)
-
-        self.streamtype = StreamType.PUPIL
-        if self.autoload:
-            self.load()
+class ZmqStream(HarpStream):
+    def __init__(self,
+                 eventcode: int,
+                 streamtype: StreamType,
+                 filenames: list[str],
+                 dtypes: list[tuple[str, type]],
+                 **kw):
+        self.streamtype = streamtype
+        self.filenames = filenames
+        self.dtypes = dtypes
+        super(ZmqStream, self).__init__(eventcode, **kw)
 
     def resample(self):
         pass
 
     def convert_to_si(self, data=None):
         pass
+
+    def load(self):
+        super(ZmqStream, self).load()
+        self.data.rename(columns={'Value': 'Counter'}, inplace=True)
+        zmq_data = load_zeromq(self.filenames, self.dtypes, root=self.rootfolder)
+        self.data = self.data.join(zmq_data, on='Counter')
 
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)
@@ -28,145 +37,168 @@ class PupilStream(Stream):
         shift_stream_index(self.data, offset)
 
 
-class GliaStream(Stream):
-    def __init__(self, **kw):
-        super(GliaStream, self).__init__(**kw)
-
-        self.streamtype = StreamType.GLIA
-        if self.autoload:
-            self.load()
-
-    def resample(self):
-        pass
-
-    def convert_to_si(self, data=None):
-        pass
-
-    def export_to_csv(self, export_path):
-        self.data.to_csv(export_path)
-
-    def add_clock_offset(self, offset):
-        shift_stream_index(self.data, offset)
+class PupilGazeStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(PupilGazeStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.PUPIL,
+            filenames=[
+                'PupilLabs/Gaze_Frame0.bin',
+                'PupilLabs/Gaze_Frame1.bin',
+                'PupilLabs/Gaze_Frame2.bin'],
+            dtypes=[
+                [('SensorId', np.string_, 36)],
+                [('Timestamp', np.uint64)],
+                [('GazeX', np.single), ('GazeY', np.single)]],
+            **kw)
 
 
-class UnityStream(Stream):
-    def __init__(self, **kw):
-        super(UnityStream, self).__init__(**kw)
-
-        self.streamtype = StreamType.UNITY
-        if self.autoload:
-            self.load()
-
-    def resample(self):
-        pass
-
-    def convert_to_si(self, data=None):
-        pass
-
-    def export_to_csv(self, export_path):
-        self.data.to_csv(export_path)
-
-    def add_clock_offset(self, offset):
-        shift_stream_index(self.data, offset)
-
-
-class PupilGazeStream(PupilStream):
-    def __init__(self, **kw):
-        super(PupilGazeStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['PupilLabs/Gaze_Frame0.bin', 'PupilLabs/Gaze_Frame1.bin', 'PupilLabs/Gaze_Frame2.bin'],
-            [[('SensorId', np.string_, 36)], [('Timestamp', np.uint64)], [('GazeX', np.single), ('GazeY', np.single)]],
-            root=self.rootfolder
-        )
+class PupilWorldCameraStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(PupilWorldCameraStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.PUPIL,
+            filenames=[
+                'PupilLabs/WorldCamera_Frame0.bin',
+                'PupilLabs/WorldCamera_Frame1.bin',
+                'PupilLabs/WorldCamera_Frame2.bin'],
+            dtypes=[
+                [('SensorId', np.string_, 36)],
+                [('Format', np.uint32),
+                 ('Width', np.uint32),
+                 ('Height', np.uint32),
+                 ('Sequence', np.uint32),
+                 ('Timestamp', np.uint64),
+                 ('DataBytes', np.uint32),
+                 ('Reserved', np.uint32)],
+                None],
+            **kw)
 
 
-class PupilWorldCameraStream(PupilStream):
-    def __init__(self, **kw):
-        super(PupilWorldCameraStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['PupilLabs/WorldCamera_Frame0.bin', 'PupilLabs/WorldCamera_Frame1.bin', 'PupilLabs/WorldCamera_Frame2.bin'],
-            [[('SensorId', np.string_, 36)], [('Format', np.uint32), ('Width', np.uint32), ('Height', np.uint32), ('Sequence', np.uint32), ('Timestamp', np.uint64), ('DataBytes', np.uint32), ('Reserved', np.uint32)], None],
-            root=self.rootfolder
-        )
-
-
-class GliaEyeTrackingStream(GliaStream):
-    def __init__(self, **kw):
-        super(GliaEyeTrackingStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['Glia/EyeTracking_Frame1.bin', 'Glia/EyeTracking_Frame2.bin'],
-            [[('HardwareTime', np.ulonglong), ('OmniceptTime', np.ulonglong), ('SystemTime', np.ulonglong)], 
-             [('CombinedGaze.X', np.single), ('CombinedGaze.Y', np.single), ('CombinedGaze.Z', np.single), ('LeftOpenness', np.single), ('LeftOpennessConfidence', np.single), ('LeftDilation', np.single), ('LeftDilationConfidence', np.single), ('LeftPosition.X', np.single), ('LeftPosition.Y', np.single), ('RightOpenness', np.single), ('RightOpennessConfidence', np.single), ('RightDilation', np.single), ('RightDilationConfidence', np.single), ('RightPosition.X', np.single), ('RightPosition.Y', np.single)]],
-            root=self.rootfolder
-        )
-
-
-class GliaHeartRateStream(GliaStream):
-    def __init__(self, **kw):
-        super(GliaEyeTrackingStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['Glia/HeartRate_Frame1.bin', 'Glia/HeartRate_Frame2.bin'],
-            [[('HardwareTime', np.ulonglong), ('OmniceptTime', np.ulonglong), ('SystemTime', np.ulonglong)], 
-             [('HardwareTime', np.uintc)]],
-            root=self.rootfolder
-        )
+class GliaEyeTrackingStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(GliaEyeTrackingStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.GLIA,
+            filenames=[
+                'Glia/EyeTracking_Frame1.bin',
+                'Glia/EyeTracking_Frame2.bin'],
+            dtypes=[
+                [('HardwareTime', np.ulonglong),
+                 ('OmniceptTime', np.ulonglong),
+                 ('SystemTime', np.ulonglong)],
+                [('CombinedGaze.X', np.single),
+                 ('CombinedGaze.Y', np.single),
+                 ('CombinedGaze.Z', np.single),
+                 ('LeftOpenness', np.single),
+                 ('LeftOpennessConfidence', np.single),
+                 ('LeftDilation', np.single),
+                 ('LeftDilationConfidence', np.single),
+                 ('LeftPosition.X', np.single),
+                 ('LeftPosition.Y', np.single),
+                 ('RightOpenness', np.single),
+                 ('RightOpennessConfidence', np.single),
+                 ('RightDilation', np.single),
+                 ('RightDilationConfidence', np.single),
+                 ('RightPosition.X', np.single),
+                 ('RightPosition.Y', np.single)]],
+            **kw)
 
 
-class GliaImuStream(GliaStream):
-    def __init__(self, **kw):
-        super(GliaImuStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['Glia/IMU_Frame1.bin', 'Glia/IMU_Frame2.bin'],
-            [[('HardwareTime', np.ulonglong), ('OmniceptTime', np.ulonglong), ('SystemTime', np.ulonglong)], 
-             [('AccelX', np.single), ('AccelY', np.single), ('AccelZ', np.single), ('GyroX', np.single), ('GyroY', np.single), ('GyroZ', np.single)]],
-            root=self.rootfolder
-        )
-
-
-class UnityTransformStream(UnityStream):
-    def __init__(self, **kw):
-        super(UnityTransformStream, self).__init__(**kw)
-
-    def load(self):
-        self.data = load_zeromq(
-            ['VRTransform/Position_Frame1.bin', 'VRTransform/Position_Frame2.bin'],
-            [[('Timestamp', np.ulonglong)], 
-             [('Transform.Position.X', np.single), ('Transform.Position.Y', np.single), ('Transform.Position.Z', np.single), ('Transform.Forward.X', np.single), ('Transform.Forward.Y', np.single), ('Transform.Forward.Z', np.single)]],
-            root=self.rootfolder
-        )
+class GliaHeartRateStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(GliaHeartRateStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.GLIA,
+            filenames=[
+                'Glia/HeartRate_Frame1.bin',
+                'Glia/HeartRate_Frame2.bin'],
+            dtypes=[
+                [('HardwareTime', np.ulonglong),
+                 ('OmniceptTime', np.ulonglong),
+                 ('SystemTime', np.ulonglong)],
+                [('HardwareTime', np.uintc)]],
+            **kw)
 
 
-class UnityPointToOriginWorldStream(UnityStream):
-    def __init__(self, **kw):
-        super(UnityPointToOriginWorldStream, self).__init__(**kw)
+class GliaImuStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(GliaImuStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.GLIA,
+            filenames=[
+                'Glia/IMU_Frame1.bin',
+                'Glia/IMU_Frame2.bin'],
+            dtypes=[
+                [('HardwareTime', np.ulonglong),
+                 ('OmniceptTime', np.ulonglong),
+                 ('SystemTime', np.ulonglong)],
+                [('AccelX', np.single),
+                 ('AccelY', np.single),
+                 ('AccelZ', np.single),
+                 ('GyroX', np.single),
+                 ('GyroY', np.single),
+                 ('GyroZ', np.single)]],
+            **kw)
 
-    def load(self):
-        self.data = load_zeromq(
-            ['Unity_PointToOriginWorld/PointToOriginWorld_Frame1.bin', 'Unity_PointToOriginWorld/PointToOriginWorld_Frame2.bin'],
-            [[('Timestamp', np.ulonglong)], 
-             [('Origin.Position.X', np.single), ('Origin.Position.Y', np.single), ('Origin.Position.Z', np.single), ('Hand.Position.X', np.single), ('Hand.Position.Y', np.single), ('Hand.Position.Z', np.single), ('HandAxis.Angle.X', np.single), ('HandAxis.Angle.Y', np.single), ('HandAxis.Angle.Z', np.single), ('OriginAxis.Angle.X', np.single), ('Transform.Angle.Y', np.single), ('Transform.Angle.Z', np.single)]],
-            root=self.rootfolder
-        )
+
+class UnityTransformStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityTransformStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'VRTransform/Position_Frame1.bin',
+                'VRTransform/Position_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('Transform.Position.X', np.single),
+                 ('Transform.Position.Y', np.single),
+                 ('Transform.Position.Z', np.single),
+                 ('Transform.Forward.X', np.single),
+                 ('Transform.Forward.Y', np.single),
+                 ('Transform.Forward.Z', np.single)]],
+            **kw)
 
 
-class UnityPointToOriginMapStream(UnityStream):
-    def __init__(self, **kw):
-        super(UnityPointToOriginMapStream, self).__init__(**kw)
+class UnityPointToOriginWorldStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityPointToOriginWorldStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'Unity_PointToOriginWorld/PointToOriginWorld_Frame1.bin',
+                'Unity_PointToOriginWorld/PointToOriginWorld_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('Origin.Position.X', np.single),
+                 ('Origin.Position.Y', np.single),
+                 ('Origin.Position.Z', np.single),
+                 ('Hand.Position.X', np.single),
+                 ('Hand.Position.Y', np.single),
+                 ('Hand.Position.Z', np.single),
+                 ('HandAxis.Angle.X', np.single),
+                 ('HandAxis.Angle.Y', np.single),
+                 ('HandAxis.Angle.Z', np.single),
+                 ('OriginAxis.Angle.X', np.single),
+                 ('Transform.Angle.Y', np.single),
+                 ('Transform.Angle.Z', np.single)]],
+            **kw)
 
-    def load(self):
-        self.data = load_zeromq(
-            ['Unity_PointToOriginMap/PointToOriginMap_Frame1.bin', 'Unity_PointToOriginMap/PointToOriginMap_Frame2.bin'],
-            [[('Timestamp', np.ulonglong)], 
-             [('Origin.Position.X', np.single), ('Origin.Position.Y', np.single), ('Subject.Position.X', np.single), ('Subject.Position.Y', np.single), ('Point.Position.X', np.single), ('Point.Position.Y', np.single)]],
-            root=self.rootfolder
-        )
+
+class UnityPointToOriginMapStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityPointToOriginMapStream, self).__init__(
+            eventcode,
+            filenames=[
+                'Unity_PointToOriginMap/PointToOriginMap_Frame1.bin',
+                'Unity_PointToOriginMap/PointToOriginMap_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('Origin.Position.X', np.single),
+                 ('Origin.Position.Y', np.single),
+                 ('Subject.Position.X', np.single),
+                 ('Subject.Position.Y', np.single),
+                 ('Point.Position.X', np.single),
+                 ('Point.Position.Y', np.single)]],
+            **kw)


### PR DESCRIPTION
The current implementation for ZMQ streams is a generic binary loader for acquired raw binary frames. However, it didn't account for timestamping, which had to be resolved manually in the notebooks by joining two separate pieces of data as detailed in #56.

This PR refactors all ZMQ streams to derive from a common `ZmqStream` class which handles the timestamping logic automatically. It expects to receive a Harp event code in the constructor, which it will use to extract the counter value and subsequent join. The final data frame is a Harp timestamped data frame as with most other dataset streams.

Fixes #56 