### PR TITLE
Add missing unity streams 

### DIFF
--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -165,7 +165,27 @@ class UnityTransformStream(ZmqStream):
             **kw)
 
 
-class UnityPointToOriginWorldStream(ZmqStream):
+class UnityGeoreferenceStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityGeoreferenceStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'Unity/Georeference_Frame1.bin',
+                'Unity/Georeference_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('TargetPositionX', np.single),
+                 ('TargetPositionY', np.single),
+                 ('TargetPositionZ', np.single),
+                 ('TargetLongitude', np.double),
+                 ('TargetLatitude', np.double),
+                 ('TargetAltitude', np.double)
+                 ]],
+            **kw)
+
+
+class ProtocolPointToOriginWorldStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityPointToOriginWorldStream, self).__init__(
             eventcode,
@@ -190,7 +210,7 @@ class UnityPointToOriginWorldStream(ZmqStream):
             **kw)
 
 
-class UnityPointToOriginMapStream(ZmqStream):
+class ProtocolPointToOriginMapStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityPointToOriginMapStream, self).__init__(
             eventcode,
@@ -207,7 +227,7 @@ class UnityPointToOriginMapStream(ZmqStream):
                  ('Point.Position.X', np.single),
                  ('Point.Position.Y', np.single)]],
             **kw)
-class UnityNewSceneStream(ZmqStream):
+class ProtocolNewSceneStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityNewSceneStream, self).__init__(
             eventcode,
@@ -221,7 +241,7 @@ class UnityNewSceneStream(ZmqStream):
                  ('SpawnID', np.intc),
                  ('SceneDuration', np.intc)]],
             **kw)
-class UnityITIStream(ZmqStream):
+class ProtocolITIStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityITIStream, self).__init__(
             eventcode,
@@ -232,22 +252,4 @@ class UnityITIStream(ZmqStream):
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('InterTrialInterval', np.single)]],
-            **kw)
-class UnityGeoreferenceStream(ZmqStream):
-    def __init__(self, eventcode: int, **kw):
-        super(UnityGeoreferenceStream, self).__init__(
-            eventcode,
-            streamtype=StreamType.UNITY,
-            filenames=[
-                'Unity/Georeference_Frame1.bin',
-                'Unity/Georeference_Frame2.bin'],
-            dtypes=[
-                [('Timestamp', np.ulonglong)],
-                [('TargetPositionX', np.single),
-                 ('TargetPositionY', np.single),
-                 ('TargetPositionZ', np.single),
-                 ('TargetLongitude', np.double),
-                 ('TargetLatitude', np.double),
-                 ('TargetAltitude', np.double)
-                 ]],
             **kw)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -152,8 +152,8 @@ class UnityTransformStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity/Position_Frame1.bin',
-                'Unity/Position_Frame2.bin'],
+                'Unity/VRTransform_Frame1.bin',
+                'Unity/VRTransform_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('Transform.Position.X', np.single),

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -152,8 +152,8 @@ class UnityTransformStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'VRTransform/Position_Frame1.bin',
-                'VRTransform/Position_Frame2.bin'],
+                'Unity_VRTransform/Position_Frame1.bin',
+                'Unity_VRTransform/Position_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('Transform.Position.X', np.single),
@@ -220,4 +220,16 @@ class UnityNewSceneStream(ZmqStream):
                 [('SceneType', np.intc),
                  ('SpawnID', np.intc),
                  ('SecondsDuration', np.intc)]],
+            **kw)
+class UnityITIStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityITIStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'Unity_ITI/ITI_Frame1.bin',
+                'Unity_ITI/ITI_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('SecondsInterTrialInterval', np.single)]],
             **kw)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -243,6 +243,8 @@ class ProtocolNewSceneStream(ZmqStream):
                  ('SpawnID', np.intc),
                  ('SceneDuration', np.intc)]],
             **kw)
+
+
 class ProtocolItiStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(ProtocolItiStream, self).__init__(

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -219,7 +219,7 @@ class UnityNewSceneStream(ZmqStream):
                 [('Timestamp', np.ulonglong)],
                 [('SceneType', np.intc),
                  ('SpawnID', np.intc),
-                 ('SecondsDuration', np.intc)]],
+                 ('SceneDuration', np.intc)]],
             **kw)
 class UnityITIStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -233,3 +233,21 @@ class UnityITIStream(ZmqStream):
                 [('Timestamp', np.ulonglong)],
                 [('SecondsInterTrialInterval', np.single)]],
             **kw)
+class UnityGeoreferenceStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityGeoreferenceStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'Unity_GeoReference/Georeference_Frame1.bin',
+                'Unity_GeoReference/Georeference_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('TargetPositionX', np.single),
+                 ('TargetPositionY', np.single),
+                 ('TargetPositionZ', np.single),
+                 ('TargetLongitude', np.double),
+                 ('TargetLatitude', np.double),
+                 ('TargetAltitude', np.double)
+                 ]],
+            **kw)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -231,7 +231,7 @@ class UnityITIStream(ZmqStream):
                 'Unity_ITI/ITI_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
-                [('SecondsInterTrialInterval', np.single)]],
+                [('InterTrialInterval', np.single)]],
             **kw)
 class UnityGeoreferenceStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -152,8 +152,8 @@ class UnityTransformStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_VRTransform/Position_Frame1.bin',
-                'Unity_VRTransform/Position_Frame2.bin'],
+                'Unity/Position_Frame1.bin',
+                'Unity/Position_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('Transform.Position.X', np.single),
@@ -171,8 +171,8 @@ class UnityPointToOriginWorldStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_PointToOriginWorld/PointToOriginWorld_Frame1.bin',
-                'Unity_PointToOriginWorld/PointToOriginWorld_Frame2.bin'],
+                'Protocol/PointToOriginWorld_Frame1.bin',
+                'Protocol/PointToOriginWorld_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('Origin.Position.X', np.single),
@@ -196,8 +196,8 @@ class UnityPointToOriginMapStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_PointToOriginMap/PointToOriginMap_Frame1.bin',
-                'Unity_PointToOriginMap/PointToOriginMap_Frame2.bin'],
+                'Protocol/PointToOriginMap_Frame1.bin',
+                'Protocol/PointToOriginMap_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('Origin.Position.X', np.single),
@@ -213,8 +213,8 @@ class UnityNewSceneStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_NewScene/NewScene_Frame1.bin',
-                'Unity_NewScene/NewScene_Frame2.bin'],
+                'Protocol/NewScene_Frame1.bin',
+                'Protocol/NewScene_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('SceneType', np.intc),
@@ -227,8 +227,8 @@ class UnityITIStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_ITI/ITI_Frame1.bin',
-                'Unity_ITI/ITI_Frame2.bin'],
+                'Protocol/ITI_Frame1.bin',
+                'Protocol/ITI_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('InterTrialInterval', np.single)]],
@@ -239,8 +239,8 @@ class UnityGeoreferenceStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
-                'Unity_GeoReference/Georeference_Frame1.bin',
-                'Unity_GeoReference/Georeference_Frame2.bin'],
+                'Unity/Georeference_Frame1.bin',
+                'Unity/Georeference_Frame2.bin'],
             dtypes=[
                 [('Timestamp', np.ulonglong)],
                 [('TargetPositionX', np.single),

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -187,7 +187,7 @@ class UnityGeoreferenceStream(ZmqStream):
 
 class ProtocolPointToOriginWorldStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
-        super(UnityPointToOriginWorldStream, self).__init__(
+        super(ProtocolPointToOriginWorldStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
@@ -212,7 +212,7 @@ class ProtocolPointToOriginWorldStream(ZmqStream):
 
 class ProtocolPointToOriginMapStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
-        super(UnityPointToOriginMapStream, self).__init__(
+        super(ProtocolPointToOriginMapStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
@@ -231,7 +231,7 @@ class ProtocolPointToOriginMapStream(ZmqStream):
 
 class ProtocolNewSceneStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
-        super(UnityNewSceneStream, self).__init__(
+        super(ProtocolNewSceneStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[
@@ -245,7 +245,7 @@ class ProtocolNewSceneStream(ZmqStream):
             **kw)
 class ProtocolITIStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
-        super(UnityITIStream, self).__init__(
+        super(ProtocolITIStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -207,3 +207,17 @@ class UnityPointToOriginMapStream(ZmqStream):
                  ('Point.Position.X', np.single),
                  ('Point.Position.Y', np.single)]],
             **kw)
+class UnityNewSceneStream(ZmqStream):
+    def __init__(self, eventcode: int, **kw):
+        super(UnityNewSceneStream, self).__init__(
+            eventcode,
+            streamtype=StreamType.UNITY,
+            filenames=[
+                'Unity_NewScene/NewScene_Frame1.bin',
+                'Unity_NewScene/NewScene_Frame2.bin'],
+            dtypes=[
+                [('Timestamp', np.ulonglong)],
+                [('SceneType', np.intc),
+                 ('SpawnID', np.intc),
+                 ('SecondsDuration', np.intc)]],
+            **kw)

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -121,7 +121,7 @@ class GliaHeartRateStream(ZmqStream):
                 [('HardwareTime', np.ulonglong),
                  ('OmniceptTime', np.ulonglong),
                  ('SystemTime', np.ulonglong)],
-                [('HardwareTime', np.uintc)]],
+                [('HeartRate', np.uintc)]],
             **kw)
 
 

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -227,6 +227,8 @@ class ProtocolPointToOriginMapStream(ZmqStream):
                  ('Point.Position.X', np.single),
                  ('Point.Position.Y', np.single)]],
             **kw)
+
+
 class ProtocolNewSceneStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
         super(UnityNewSceneStream, self).__init__(

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -243,9 +243,9 @@ class ProtocolNewSceneStream(ZmqStream):
                  ('SpawnID', np.intc),
                  ('SceneDuration', np.intc)]],
             **kw)
-class ProtocolITIStream(ZmqStream):
+class ProtocolItiStream(ZmqStream):
     def __init__(self, eventcode: int, **kw):
-        super(ProtocolITIStream, self).__init__(
+        super(ProtocolItiStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=[


### PR DESCRIPTION
This PR does:

- In the heartrate stream rename the HardwareTime to HeartRate
- Rename `ProtocolPointToOriginWorld`, `ProtocolPointToOriginMap`.
- Add `ProtocolNewSceneStream`.
- Add `ProtocolItiStream`.
- Add `UnityGeoreferenceStream`.