### PR TITLE
Add Raycast combined gaze info

### DIFF
--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -105,7 +105,10 @@ class GliaEyeTrackingStream(ZmqStream):
                  ('RightDilation', np.single),
                  ('RightDilationConfidence', np.single),
                  ('RightPosition.X', np.single),
-                 ('RightPosition.Y', np.single)]],
+                 ('RightPosition.Y', np.single),
+                 ('Raycast.X', np.single),
+                 ('Raycast.Y', np.single),
+                 ('Raycast.Z', np.single)]],
             **kw)
 
 


### PR DESCRIPTION
Add a new component to the Glia eye tracking stream containing the data from VR Engine physics raycast hit points.