### PR TITLE
Add interpolated georeference for VR walks

### DIFF
--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -16,10 +16,10 @@ class ZmqStream(HarpStream):
         dtypes: list[tuple[str, type]],
         **kw,
     ):
-        self.streamtype = streamtype
         self.filenames = filenames
         self.dtypes = dtypes
         super(ZmqStream, self).__init__(eventcode, **kw)
+        self.streamtype = streamtype
 
     def resample(self):
         pass


### PR DESCRIPTION
This PR introduces a new utility method `add_unity_georeference`, which computes an interpolated space-time table from a set of known correspondences between geolocation and VR cartesian coordinates recorded at acquisition time. This makes it easier to operate with the dataset in a similar way to outdoor walks.