### PR TITLE
Add support for exporting EEG data as dataframe

### DIFF
--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -54,5 +54,8 @@ class EegStream(Stream):
             self.server_lsl_marker["Seconds"] += offset
         self.data.np_time += offset
 
+    def to_frame(self):
+        return pd.DataFrame(data=self.data.np_eeg, index=self.data.np_time)
+
     def __str__(self):
         return f"EEG stream from device {self.device}, stream {self.streamlabel}"


### PR DESCRIPTION
EEG raw data is only rarely manipulated and explored directly as other data streams. However, it is instructive to have a reference implementation showing how to obtain a `DataFrame` object if necessary.