### PR TITLE
Ensure LSL synch markers are not event markers

### DIFF
--- a/pluma/io/eeg.py
+++ b/pluma/io/eeg.py
@@ -119,9 +119,13 @@ def load_server_lsl_markers(
     return df
 
 
-def synchronize_eeg_to_harp(server_lsl_markers: pd.DataFrame, min_q_r2: float = 0.999) -> LinearRegression:
-    valid_samples = pd.notna(server_lsl_markers["EegTimestamp"].values) & pd.notna(
-        server_lsl_markers["Seconds"].values
+def synchronize_eeg_to_harp(
+    server_lsl_markers: pd.DataFrame, min_q_r2: float = 0.999, event_mask: int = 0x8000
+) -> LinearRegression:
+    valid_samples = (
+        pd.notna(server_lsl_markers["EegTimestamp"].values)
+        & pd.notna(server_lsl_markers["Seconds"].values)
+        & (server_lsl_markers["MarkerIdx"] & event_mask == 0)
     )
     raw_harp_time = HarpStream.to_seconds(server_lsl_markers["Seconds"].values)
     eeg_time = server_lsl_markers["EegTimestamp"].values


### PR DESCRIPTION
During EEG synchronization the process applies a linear regression between native EEG timestamps and harp timestamps. Currently this regression was applied indiscriminately across both protocol-specific and protocol-agnostic counters.

This PR automatically excludes all protocol-specific event markers from the regression to ensure only uniquely pseudo-random counters are included in the fit to prevent from inadvertent biases coming from specific protocol event logic.

Fixes #74 