### PR TITLE
Fix column order of nav data in add_unity_georeference

### DIFF
--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -110,8 +110,8 @@ class Dataset:
         alt_model = LinearRegression().fit(geodata[["TargetPositionY"]].values, geodata[["TargetAltitude"]])
         navdata = DataFrame(
             data={
-                "Longitude": lon_model.predict(posdata[["Transform.Position.Z"]]).reshape(-1),
                 "Latitude": lat_model.predict(posdata[["Transform.Position.X"]]).reshape(-1),
+                "Longitude": lon_model.predict(posdata[["Transform.Position.Z"]]).reshape(-1),
                 "Elevation": alt_model.predict(posdata[["Transform.Position.Y"]]).reshape(-1),
             },
             index=posdata.index,


### PR DESCRIPTION
To match the one from UBX. This specific order is required by the way the resampling function accesses the navigation attributes using a range slice:

https://github.com/emotional-cities/pluma-analysis/blob/97aa3a43b4b9dd8c7a6f2f13c9761d0b41b452ca/pluma/preprocessing/resampling.py#L59-L60

In the future the resampling function could be made robust to different columns orders.

This is required to resample the data to GeoJSON.
