### PR TITLE
Allow decoding UTC time without calibration signal

### DIFF
--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -82,8 +82,12 @@ class UbxStream(Stream):
         if decode_utc_time is True:
             # GPS epoch
             epoch = pd.Timestamp(1980, 1, 6)
-            reference = self.data["TIM_TM2"].Message[0]
-            offset = epoch + pd.Timedelta(weeks=reference.wnR)
+            if calibrate_clock:
+                reference = self.data["TIM_TM2"].Message[0]
+                offset = epoch + pd.Timedelta(weeks=reference.wnR)
+            else:
+                reference = self.data["TIM_TP"].Message[0]
+                offset = epoch + pd.Timedelta(weeks=reference.week)
             NavData["Time_UTC"] = offset + NavData["Time_iTow"].astype("timedelta64[ms]")
         self.positiondata = NavData
         return NavData


### PR DESCRIPTION
To allow loading datasets where hardware clock synchronization with the GPS module failed or is unavailable, we extend the decoding of UTC time to use the `TIM_TP` (precision timepulse) message instead of `TIM_TM2` (input timemark) message.

This fallback decoding takes place in the cases where `calibrate_clock` has been set to `False`.