### PR TITLE
Add comma separator when exporting multiple items

### DIFF
--- a/pluma/templates/metadata_template.j2
+++ b/pluma/templates/metadata_template.j2
@@ -32,7 +32,7 @@
         "email": [
           {"value" : "{{ contact.email }}"}
         ]
-      }
+      }{{ "," if not loop.last }}
       {%- endfor %}
     ],
     "themes": [
@@ -42,11 +42,11 @@
           {% for concept in theme.concepts %}
           {
             "id": "{{ concept }}"
-          }
+          }{{ "," if not loop.last }}
           {% endfor %}
         ],
         "scheme": "{{ theme.scheme_url }}"
-      }
+      }{{ "," if not loop.last }}
       {%- endfor %}
     ],
     "formats": [


### PR DESCRIPTION
The jinja2 template failed to handle multiple item lists correctly since it did not emit the comma separator. This short fix uses the [`loop.last`](https://jinja.palletsprojects.com/en/stable/templates/#for) control variable to emit separators except for the last item in the list.