### PR TITLE
Prefer dataset label as record id

### DIFF
--- a/pluma/export/ogcapi/records.py
+++ b/pluma/export/ogcapi/records.py
@@ -43,7 +43,7 @@ class RecordProperties:
 class DatasetRecord:
     def __init__(self, dataset: Dataset, gdf: GeoDataFrame, properties: RecordProperties) -> None:
         root_path = Path(dataset.rootfolder.path)
-        self.id = f"{root_path.name.lower()}"
+        self.id = dataset.datasetlabel or f"{root_path.name.lower()}"
         self.start_date = gdf.index[0]
         self.end_date = gdf.index[-1]
         self.created_timestamp = pd.Timestamp(datetime.now(timezone.utc))


### PR DESCRIPTION
This PR makes it more flexible to configure dataset record id by reading it from the `datasetlabel` attribute instead of force extracting it from the root folder name.