### PR TITLE
Avoid duplicating timestamp calculations

### DIFF
--- a/pluma/io/accelerometer.py
+++ b/pluma/io/accelerometer.py
@@ -3,7 +3,7 @@ import warnings
 import pandas as pd
 
 from typing import Union
-from pluma.io.harp import _HARP_T0
+from pluma.io.harp import to_datetime
 from pluma.io.path_helper import ComplexPath, ensure_complexpath
 
 _accelerometer_header = [
@@ -30,7 +30,7 @@ _accelerometer_header = [
     "AccCalibEnabled",
     "MagCalibEnabled",
     "Temperature",
-    "Seconds",
+    "Timestamp",
     "SoftwareTimestamp",
 ]
 
@@ -40,12 +40,17 @@ def load_accelerometer(
 ) -> pd.DataFrame:
     """Loads the raw accelerometer data from file to a pandas DataFrame.
 
-    Args:
-        filename (str, optional): Input file name to target. Defaults to 'Accelerometer.csv'.
-        root (Union[str, ComplexPath], optional): Root path where filename is expected to be found. Defaults to ''.
+    Parameters
+    ----------
+        filename: str
+            Input file name to target. Defaults to 'Accelerometer.csv'.
+        root: str or ComplexPath
+            Root path where filename is expected to be found. Defaults to ''.
 
-    Returns:
-        pd.DataFrame: Dataframe with descriptive data indexed by time (Seconds)
+    Returns
+    -------
+        DataFrame
+            Dataframe with descriptive data indexed by time
     """
     path = ensure_complexpath(root)
     path.join(filename)
@@ -59,7 +64,7 @@ def load_accelerometer(
         warnings.warn(f"Accelerometer stream file {path} could not be found.")
         return
 
-    acc_df["Seconds"] = _HARP_T0 + pd.to_timedelta(acc_df["Seconds"].values, "s")
-    acc_df["SoftwareTimestamp"] = _HARP_T0 + pd.to_timedelta(acc_df["SoftwareTimestamp"].values, "s")
-    acc_df.set_index("Seconds", inplace=True)
+    acc_df["Timestamp"] = to_datetime(acc_df["Timestamp"].values)
+    acc_df["SoftwareTimestamp"] = to_datetime(acc_df["SoftwareTimestamp"].values)
+    acc_df.set_index("Timestamp", inplace=True)
     return acc_df

--- a/pluma/stream/ecg.py
+++ b/pluma/stream/ecg.py
@@ -15,7 +15,7 @@ class EcgStream(HarpStream):
     def __init__(self, eventcode: int, clockreferenceid: ClockRefId = ClockRefId.HARP, **kw):
         super().__init__(
             eventcode,
-            data=pd.DataFrame(columns=["Seconds", "Value"]),
+            data=pd.DataFrame(columns=["Timestamp", "Value"]),
             si_conversion=SiUnitConversion(),
             clockreferenceid=clockreferenceid,
             **kw,

--- a/pluma/stream/eeg.py
+++ b/pluma/stream/eeg.py
@@ -4,9 +4,9 @@ import pandas as pd
 from typing import Optional
 
 from pluma.stream import Stream, StreamType
+from pluma.io.harp import to_datetime
 from pluma.io.eeg import load_eeg, synchronize_eeg_to_harp
 from pluma.sync import ClockRefId
-from pluma.stream.harp import HarpStream
 
 from mne.io import Raw
 
@@ -44,14 +44,12 @@ class EegStream(Stream):
     def align_to_harp(self):
         print("Attempting to automatically correct eeg timestamps to harp timestamps...")
         eeg_to_harp_model = synchronize_eeg_to_harp(self.server_lsl_marker)
-        self.data.np_time = HarpStream.from_seconds(
-            eeg_to_harp_model.predict(self.data.np_time.reshape(-1, 1)).flatten()
-        )
+        self.data.np_time = to_datetime(eeg_to_harp_model.predict(self.data.np_time.reshape(-1, 1)).flatten())
         print("Done.")
 
     def add_clock_offset(self, offset):
         if self.server_lsl_marker is not None:
-            self.server_lsl_marker["Seconds"] += offset
+            self.server_lsl_marker["Timestamp"] += offset
         self.data.np_time += offset
 
     def to_frame(self):

--- a/pluma/stream/georeference.py
+++ b/pluma/stream/georeference.py
@@ -10,7 +10,7 @@ warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
 
 class Georeference:
-    _georeference_header = ["Seconds", "Longitude", "Latitude", "Elevation"]
+    _georeference_header = ["Timestamp", "Longitude", "Latitude", "Elevation"]
 
     def __init__(
         self,
@@ -83,8 +83,8 @@ class Georeference:
             return None
         else:
             if self._validate_build_spacetime_from_dataframe(df) is True:
-                if not (df.index.name == "Seconds"):
-                    df.set_index("Seconds", inplace=True)
+                if not (df.index.name == "Timestamp"):
+                    df.set_index("Timestamp", inplace=True)
                 gdf = geopandas.GeoDataFrame(
                     df,
                     geometry=geopandas.points_from_xy(
@@ -95,7 +95,7 @@ class Georeference:
 
     def _validate_build_spacetime_from_dataframe(self, df: pd.DataFrame) -> bool:
         offset = 0
-        if df.index.name == "Seconds":
+        if df.index.name == "Timestamp":
             offset = 1
 
         expected = [x for x in Georeference._georeference_header[offset:]]

--- a/pluma/stream/harp.py
+++ b/pluma/stream/harp.py
@@ -1,9 +1,8 @@
-import numpy as np
 import pandas as pd
 import datetime
 
 from pluma.stream import Stream, StreamType
-from pluma.io.harp import load_harp_stream, _HARP_T0
+from pluma.io.harp import load_harp_stream
 
 from pluma.stream.siconversion import SiUnitConversion
 
@@ -26,7 +25,7 @@ class HarpStream(Stream):
     def __init__(
         self,
         eventcode: int,
-        data: pd.DataFrame = pd.DataFrame(columns=["Seconds", "Value"]),
+        data: pd.DataFrame = pd.DataFrame(columns=["Timestamp", "Value"]),
         si_conversion: SiUnitConversion = SiUnitConversion(),
         clockreferenceid: ClockRefId = ClockRefId.HARP,
         **kw,
@@ -58,16 +57,6 @@ class HarpStream(Stream):
     def __str__(self):
         return f"Harp stream from device \
 		{self.device}, stream {self.streamlabel}({self.eventcode})"
-
-    @staticmethod
-    def to_seconds(index):
-        # Converts an harp referred timedelta to seconds (double)
-        return (index - np.datetime64(_HARP_T0)) / np.timedelta64(1, "s")
-
-    @staticmethod
-    def from_seconds(index):
-        # Converts seconds (double) back to a harp referenced timedelta
-        return (_HARP_T0 + pd.to_timedelta(index, "s")).values
 
     def export_to_csv(self, root_path, **kwargs):
         export_stream_to_csv(self, root_path, **kwargs)

--- a/pluma/stream/ubx.py
+++ b/pluma/stream/ubx.py
@@ -3,7 +3,7 @@ import pandas as pd
 from dotmap import DotMap
 
 from pluma.stream import Stream, StreamType
-from pluma.stream.harp import HarpStream
+from pluma.io.harp import to_datetime
 from pluma.io.ubx import load_ubx_event_stream, _UBX_MSGIDS
 from pluma.sync import ClockRefId
 
@@ -76,9 +76,9 @@ class UbxStream(Stream):
         if calibrate_clock is True:
             iTow = NavData["Time_iTow"].values.reshape(-1, 1)
             iTowCorrected = self.calibrate_itow(iTow)
-            iTowCorrected = pd.DataFrame(HarpStream.from_seconds(iTowCorrected))
-            iTowCorrected.columns = ["Seconds"]
-            NavData.set_index(iTowCorrected["Seconds"], inplace=True)
+            iTowCorrected = pd.DataFrame(to_datetime(iTowCorrected))
+            iTowCorrected.columns = ["Timestamp"]
+            NavData.set_index(iTowCorrected["Timestamp"], inplace=True)
         if decode_utc_time is True:
             # GPS epoch
             epoch = pd.Timestamp(1980, 1, 6)

--- a/pluma/sync/ubx2harp.py
+++ b/pluma/sync/ubx2harp.py
@@ -2,6 +2,7 @@ import numpy as np
 from dataclasses import dataclass
 from sklearn.linear_model import LinearRegression
 
+from pluma.io.harp import to_harptime
 from pluma.stream.harp import HarpStream
 from pluma.stream.ubx import UbxStream, _UBX_MSGIDS
 
@@ -171,7 +172,7 @@ def get_clockcalibration_model(sync_lookup: SyncLookup, r2_min_qc: float = 0.99)
     harp_ts = sync_lookup.harp_ts
     align_lookup = sync_lookup.align_lookup
 
-    harp_ts_seconds = HarpStream.to_seconds(harp_ts.raw_ts_array)
+    harp_ts_seconds = to_harptime(harp_ts.raw_ts_array)
     x_gps_time = ubx_ts.raw_ts_array[align_lookup[:, 0]].reshape(-1, 1)
     y_harp_time = harp_ts_seconds[align_lookup[:, 1]]
     model = LinearRegression().fit(x_gps_time, y_harp_time)


### PR DESCRIPTION
This PR avoids duplication of Harp and E4 timestamp conversion code throughout the readers to make it easier to maintain any future changes.