### PR TITLE
Add missing dependency required by heartpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "dotmap",
     "mne",
     "heartpy",
+    "setuptools",
     "simplekml",
     "isodate",
     "jinja2"


### PR DESCRIPTION
Sadly setuptools is required by heartpy due to a stray import statement. This is being tracked in the heartpy repo but not expected to be resolved anytime soon as the package appears not to be active.