### PR TITLE
Add missing dependency for loading NEDF files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tilemapbase",
     "dotmap",
     "mne",
+    "defusedxml",
     "heartpy",
     "setuptools",
     "simplekml",


### PR DESCRIPTION
The `defusedxml` package is an optional MNE dependency which is however required for loading NEDF files. We therefore add it as an explicit dependency since NEDF is the main storage format for EEG data.