### PR TITLE
Avoid casting overflow for numpy compatibility

### DIFF
--- a/pluma/io/harp.py
+++ b/pluma/io/harp.py
@@ -92,10 +92,10 @@ def read_harp_bin(file: Union[str, ComplexPath], time_offset: float = 0) -> pd.D
     if len(data) == 0:
         return None
 
-    stride = data[1] + 2
+    stride = int(data[1] + 2)
     length = len(data) // stride
     payloadsize = stride - 12
-    payloadtype = _payloadtypes[data[4] & ~0x10]
+    payloadtype = _payloadtypes[data[4] & ~np.uint8(0x10)]
     elementsize = payloadtype.itemsize
     payloadshape = (length, payloadsize // elementsize)
     seconds = np.ndarray(length, dtype=np.uint32, buffer=data, offset=5, strides=stride)


### PR DESCRIPTION
NumPy 2.0 has more strict rules regarding casting and overflowing of operators. Here we recreate the changes in https://github.com/harp-tech/harp-python/pull/35 to ensure compatibility.

In the future we should really remove this custom code and simply install harp-python, but we need to think how to deal with the requirement for dealing with complex S3 bucket paths, so we defer this to a future update.