### PR TITLE
Add clock source identifier to timestamp column

### DIFF
--- a/pluma/stream/pupil.py
+++ b/pluma/stream/pupil.py
@@ -16,7 +16,7 @@ class PupilGazeStream(ZmqStream):
             ],
             dtypes=[
                 [("SensorId", np.bytes_, 36)],
-                [("Timestamp", np.uint64)],
+                [("PupilTime", np.uint64)],
                 [("GazeX", np.single), ("GazeY", np.single)],
             ],
             **kw,
@@ -40,7 +40,7 @@ class PupilWorldCameraStream(ZmqStream):
                     ("Width", np.uint32),
                     ("Height", np.uint32),
                     ("Sequence", np.uint32),
-                    ("Timestamp", np.uint64),
+                    ("PupilTime", np.uint64),
                     ("DataBytes", np.uint32),
                     ("Reserved", np.uint32),
                 ],

--- a/pluma/stream/unity.py
+++ b/pluma/stream/unity.py
@@ -11,7 +11,7 @@ class UnityTransformStream(ZmqStream):
             streamtype=StreamType.UNITY,
             filenames=["Unity/VRTransform_Frame1.bin", "Unity/VRTransform_Frame2.bin"],
             dtypes=[
-                [("Timestamp", np.ulonglong)],
+                [("SystemDateTime", np.ulonglong)],
                 [
                     ("Transform.Position.X", np.single),
                     ("Transform.Position.Y", np.single),
@@ -35,7 +35,7 @@ class UnityGeoreferenceStream(ZmqStream):
                 "Unity/Georeference_Frame2.bin",
             ],
             dtypes=[
-                [("Timestamp", np.ulonglong)],
+                [("SystemDateTime", np.ulonglong)],
                 [
                     ("TargetPositionX", np.single),
                     ("TargetPositionY", np.single),
@@ -59,7 +59,7 @@ class ProtocolPointToOriginWorldStream(ZmqStream):
                 "Protocol/PointToOriginWorld_Frame2.bin",
             ],
             dtypes=[
-                [("Timestamp", np.ulonglong)],
+                [("SystemDateTime", np.ulonglong)],
                 [
                     ("Origin.Position.X", np.single),
                     ("Origin.Position.Y", np.single),
@@ -89,7 +89,7 @@ class ProtocolPointToOriginMapStream(ZmqStream):
                 "Protocol/PointToOriginMap_Frame2.bin",
             ],
             dtypes=[
-                [("Timestamp", np.ulonglong)],
+                [("SystemDateTime", np.ulonglong)],
                 [
                     ("Origin.Position.X", np.single),
                     ("Origin.Position.Y", np.single),
@@ -110,7 +110,7 @@ class ProtocolNewSceneStream(ZmqStream):
             streamtype=StreamType.UNITY,
             filenames=["Protocol/NewScene_Frame1.bin", "Protocol/NewScene_Frame2.bin"],
             dtypes=[
-                [("Timestamp", np.ulonglong)],
+                [("SystemDateTime", np.ulonglong)],
                 [
                     ("SceneType", np.intc),
                     ("SpawnID", np.intc),
@@ -127,6 +127,6 @@ class ProtocolItiStream(ZmqStream):
             eventcode,
             streamtype=StreamType.UNITY,
             filenames=["Protocol/ITI_Frame1.bin", "Protocol/ITI_Frame2.bin"],
-            dtypes=[[("Timestamp", np.ulonglong)], [("InterTrialInterval", np.single)]],
+            dtypes=[[("SystemDateTime", np.ulonglong)], [("InterTrialInterval", np.single)]],
             **kw,
         )


### PR DESCRIPTION
To clarify the provenance of the underlying raw clock timestamps, here we add a defined clock source identifier to each timestamp column for ZMQ streams:
  - `PupilTime`: Acquisition timestamp for Pupil device streams, in microseconds
  - `SystemDateTime`: Current computer OS date and time, in microseconds
