### PR TITLE
Add support for aligning ZMQ stream timestamps

### DIFF
--- a/pluma/stream/glia.py
+++ b/pluma/stream/glia.py
@@ -9,6 +9,8 @@ class GliaEyeTrackingStream(ZmqStream):
         super(GliaEyeTrackingStream, self).__init__(
             eventcode,
             streamtype=StreamType.GLIA,
+            clocksource="OmniceptTime",
+            clockunit="us",
             filenames=["Glia/EyeTracking_Frame1.bin", "Glia/EyeTracking_Frame2.bin"],
             dtypes=[
                 [
@@ -46,6 +48,8 @@ class GliaHeartRateStream(ZmqStream):
         super(GliaHeartRateStream, self).__init__(
             eventcode,
             streamtype=StreamType.GLIA,
+            clocksource="OmniceptTime",
+            clockunit="us",
             filenames=["Glia/HeartRate_Frame1.bin", "Glia/HeartRate_Frame2.bin"],
             dtypes=[
                 [
@@ -64,6 +68,8 @@ class GliaImuStream(ZmqStream):
         super(GliaImuStream, self).__init__(
             eventcode,
             streamtype=StreamType.GLIA,
+            clocksource="OmniceptTime",
+            clockunit="us",
             filenames=["Glia/IMU_Frame1.bin", "Glia/IMU_Frame2.bin"],
             dtypes=[
                 [

--- a/pluma/stream/pupil.py
+++ b/pluma/stream/pupil.py
@@ -9,6 +9,8 @@ class PupilGazeStream(ZmqStream):
         super(PupilGazeStream, self).__init__(
             eventcode,
             streamtype=StreamType.PUPIL,
+            clocksource="PupilTime",
+            clockunit="us",
             filenames=[
                 "PupilLabs/Gaze_Frame0.bin",
                 "PupilLabs/Gaze_Frame1.bin",
@@ -28,6 +30,8 @@ class PupilWorldCameraStream(ZmqStream):
         super(PupilWorldCameraStream, self).__init__(
             eventcode,
             streamtype=StreamType.PUPIL,
+            clocksource="PupilTime",
+            clockunit="us",
             filenames=[
                 "PupilLabs/WorldCamera_Frame0.bin",
                 "PupilLabs/WorldCamera_Frame1.bin",

--- a/pluma/stream/unity.py
+++ b/pluma/stream/unity.py
@@ -9,6 +9,8 @@ class UnityTransformStream(ZmqStream):
         super(UnityTransformStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=["Unity/VRTransform_Frame1.bin", "Unity/VRTransform_Frame2.bin"],
             dtypes=[
                 [("SystemDateTime", np.ulonglong)],
@@ -30,6 +32,8 @@ class UnityGeoreferenceStream(ZmqStream):
         super(UnityGeoreferenceStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=[
                 "Unity/Georeference_Frame1.bin",
                 "Unity/Georeference_Frame2.bin",
@@ -54,6 +58,8 @@ class ProtocolPointToOriginWorldStream(ZmqStream):
         super(ProtocolPointToOriginWorldStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=[
                 "Protocol/PointToOriginWorld_Frame1.bin",
                 "Protocol/PointToOriginWorld_Frame2.bin",
@@ -84,6 +90,8 @@ class ProtocolPointToOriginMapStream(ZmqStream):
         super(ProtocolPointToOriginMapStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=[
                 "Protocol/PointToOriginMap_Frame1.bin",
                 "Protocol/PointToOriginMap_Frame2.bin",
@@ -108,6 +116,8 @@ class ProtocolNewSceneStream(ZmqStream):
         super(ProtocolNewSceneStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=["Protocol/NewScene_Frame1.bin", "Protocol/NewScene_Frame2.bin"],
             dtypes=[
                 [("SystemDateTime", np.ulonglong)],
@@ -126,6 +136,8 @@ class ProtocolItiStream(ZmqStream):
         super(ProtocolItiStream, self).__init__(
             eventcode,
             streamtype=StreamType.UNITY,
+            clocksource="SystemDateTime",
+            clockunit="us",
             filenames=["Protocol/ITI_Frame1.bin", "Protocol/ITI_Frame2.bin"],
             dtypes=[[("SystemDateTime", np.ulonglong)], [("InterTrialInterval", np.single)]],
             **kw,


### PR DESCRIPTION
Continuous alignment of ZMQ stream timestamps with the reference Harp clock has been complicated by burst transmission of messages through the TCP interface.

However, the underlying stream hardware timestamp deltas themselves have low drift on the sampling frequencies of interest for recording durations up to one hour, so this PR provides an optional alignment based on the first message received.