### PR TITLE
Fix missing imports and ensure consistent index name

### DIFF
--- a/pluma/schema/__init__.py
+++ b/pluma/schema/__init__.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import LinearRegression
 from pluma.export.streams import shift_stream_index
 from pluma.schema.outdoor import build_schema
 
-from pluma.stream.zeromq import UnityGeoreferenceStream, UnityTransformStream
+from pluma.stream.unity import UnityGeoreferenceStream, UnityTransformStream
 from pluma.sync.ubx2harp import (
     SyncLookup,
     get_clockcalibration_model,

--- a/pluma/stream/zeromq.py
+++ b/pluma/stream/zeromq.py
@@ -37,8 +37,10 @@ class ZmqStream(HarpStream):
         zmq_data = load_zeromq(self.filenames, self.dtypes, root=self.rootfolder)
         self.data = self.data.join(zmq_data, on="Counter")
         if self.clocksource is not None:
+            index_name = self.data.index.name
             counter_timedelta = pd.to_timedelta(self.data[self.clocksource] - self.data[self.clocksource][0], self.clockunit)
             self.data.index = self.data.index[0] + counter_timedelta
+            self.data.index.name = index_name
 
     def export_to_csv(self, export_path):
         self.data.to_csv(export_path)


### PR DESCRIPTION
To ensure consistent indexing behavior when realigning ZMQ streams in #91, we make sure to preserve the original index name coming from the `Counter` dataframe. A few missing imports were also fixed.